### PR TITLE
BAU - Configure the app to run on PaaS

### DIFF
--- a/ci/pipeline.yaml
+++ b/ci/pipeline.yaml
@@ -6,7 +6,7 @@ resources:
       uri: https://github.com/alphagov/di-auth-oidc-provider.git
       ignore_paths:
         - ci/pipeline.yaml
-      branch: bau-pipeline-setup
+      branch: main
 
   - name: pipeline-src
     type: git
@@ -15,7 +15,17 @@ resources:
       uri: https://github.com/alphagov/di-auth-oidc-provider.git
       paths:
         - ci/pipeline.yaml
-      branch: bau-pipeline-setup
+      branch: main
+
+  - name: di-auth-oidc-provider-upload
+    type: cf-cli
+    icon: cloud-upload
+    source:
+      api: https://api.cloud.service.gov.uk
+      username: ida-operations+paas-build-bot@digital.cabinet-office.gov.uk
+      password: ((cf-password))
+      org: gds-digital-identity-authentication
+      space: sandbox
 
 jobs:
   - name: update-pipeline
@@ -38,4 +48,30 @@ jobs:
         run:
           path: echo
           args: ["Hello world!"]
+    - task: build
+      config:
+        platform: linux
+        image_resource:
+          type: registry-image
+          source:
+            repository: gradle
+            tag: 6.7.0-jdk15@sha256:dc1a34c3ee9cadcd58e7f4582e7340cbeb2895ea3065f1569ad2f7831bf42e29
+        inputs:
+          - name: di-auth-oidc-provider
+        outputs:
+          - name: di-auth-oidc-provider
+        run:
+          path: /bin/bash
+          args:
+            - -euc
+            - |
+              cd di-auth-oidc-provider
+              gradle --no-daemon build
+              cp di-auth-oidc-provider/build/distributions/di-auth-oidc-provider.zip ../di-auth-oidc-provider/
+        - put: di-auth-oidc-provider-upload
+          params:
+            command: push
+            manifest: di-auth-oidc-provider/manifest.yml
+            path: di-auth-oidc-provider/di-auth-oidc-provider.zip
+
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,10 @@
+---
+applications:
+  - name: di-auth-oidc-provider
+    path: build/distributions/di-auth-oidc-provider.zip
+    memory: 1G
+    buildpack: java_buildpack
+    command: cd di-auth-oidc-provider && bin/di-auth-oidc-provider
+    env:
+      JAVA_HOME: "../.java-buildpack/open_jdk_jre"
+      JBP_CONFIG_OPEN_JDK_JRE: '{ jre: { version: 15.+}}'

--- a/src/main/java/uk/gov/di/HelloWorld.java
+++ b/src/main/java/uk/gov/di/HelloWorld.java
@@ -1,10 +1,12 @@
 package uk.gov.di;
 
 import static spark.Spark.get;
+import static spark.Spark.port;
 
 public class HelloWorld {
 
     public static void main(String[] args) {
+        port(8080);
         get("/hello", (req, res) -> "Hello World");
     }
 }


### PR DESCRIPTION
- Add a manifest to the application so it can run on PaaS. This has been tested to work by manually running cf push. This can be tested by visiting `https://di-auth-oidc-provider.london.cloudapps.digital/hello`
- Start modifying the pipeline to do this automatically for us.
- Configure the pipeline to listen to changes from the `main` branch.