### PR TITLE
BAU: deploy app to PaaS from the pipeline

### DIFF
--- a/ci/pipeline.yaml
+++ b/ci/pipeline.yaml
@@ -1,3 +1,9 @@
+resource_types:
+  - name: cf-cli
+    type: docker-image
+    source:
+      repository: nulldriver/cf-cli-resource
+
 resources:
   - name: di-auth-oidc-provider
     type: git
@@ -21,8 +27,8 @@ resources:
     type: cf-cli
     icon: cloud-upload
     source:
-      api: https://api.cloud.service.gov.uk
-      username: ida-operations+paas-build-bot@digital.cabinet-office.gov.uk
+      api: https://api.london.cloud.service.gov.uk
+      username: ((cf-username))
       password: ((cf-password))
       org: gds-digital-identity-authentication
       space: sandbox
@@ -55,11 +61,10 @@ jobs:
           type: registry-image
           source:
             repository: gradle
-            tag: 6.7.0-jdk15@sha256:dc1a34c3ee9cadcd58e7f4582e7340cbeb2895ea3065f1569ad2f7831bf42e29
         inputs:
           - name: di-auth-oidc-provider
         outputs:
-          - name: di-auth-oidc-provider
+          - name: di-auth-oidc-provider-zip
         run:
           path: /bin/bash
           args:
@@ -67,11 +72,11 @@ jobs:
             - |
               cd di-auth-oidc-provider
               gradle --no-daemon build
-              cp di-auth-oidc-provider/build/distributions/di-auth-oidc-provider.zip ../di-auth-oidc-provider/
-        - put: di-auth-oidc-provider-upload
-          params:
-            command: push
-            manifest: di-auth-oidc-provider/manifest.yml
-            path: di-auth-oidc-provider/di-auth-oidc-provider.zip
+              cp build/distributions/di-auth-oidc-provider.zip ../di-auth-oidc-provider-zip/
+    - put: di-auth-oidc-provider-upload
+      params:
+        command: push
+        manifest: di-auth-oidc-provider/manifest.yml
+        path: di-auth-oidc-provider-zip/di-auth-oidc-provider.zip
 
 


### PR DESCRIPTION
## What

Add further PaaS deployment tasks to the pipeline.

## Why

Enables deploying the app as long as the credentials are set correctly in SSM.