### PR TITLE
BAU - Update the PaaS CI username to use the ((cf-username)) variable

### DIFF
--- a/ci/pipeline.yaml
+++ b/ci/pipeline.yaml
@@ -22,7 +22,7 @@ resources:
     icon: cloud-upload
     source:
       api: https://api.cloud.service.gov.uk
-      username: ida-operations+paas-build-bot@digital.cabinet-office.gov.uk
+      username: ((cf-username))
       password: ((cf-password))
       org: gds-digital-identity-authentication
       space: sandbox


### PR DESCRIPTION
- The parameter store path `di-auth-oidc-provider/cf-username` has been updated with the new username for this CI user. 