### PR TITLE
BAU: Fix Java and Gradle versions in pipeline

### DIFF
--- a/ci/pipeline.yaml
+++ b/ci/pipeline.yaml
@@ -51,7 +51,7 @@ jobs:
         image_resource:
           type: registry-image
           source:
-            repository: gradle
+            repository: gradle:6.8.3-jdk15
         inputs:
           - name: di-auth-oidc-provider
         outputs:


### PR DESCRIPTION
## What

Be explicit about which Gradle image to use, the implied `gradle:latest` is JDK8, so out of sync with local and deployment environments which are all fixed at 15.

## Why

Code failed to build in pipeline once we used a Java 14+ feature.