### PR TITLE
BAU: Use correct syntax for specifying image_resource tag in pipeline.

### DIFF
--- a/ci/pipeline.yaml
+++ b/ci/pipeline.yaml
@@ -51,7 +51,8 @@ jobs:
         image_resource:
           type: registry-image
           source:
-            repository: gradle:6.8.3-jdk15
+            repository: gradle
+            tag: 6.8.3-jdk15
         inputs:
           - name: di-auth-oidc-provider
         outputs:


### PR DESCRIPTION
## What

In the previous commit we incorrectly specified the image tag as part of the repository field, this should infact be specified as a separate field in the pipeline definition.

## Why

The pipeline is still failing.