### PR TITLE
Oxsvsict - Add token endpoint

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,8 @@ def dependencyVersions = [
         dropwizard:'2.0.21',
         nimbus_oauth2_sdk: '9.3.1',
         nimbus_jose_jwt: '9.8.1',
-        junit_version: '5.6.0'
+        junit_version: '5.6.0',
+        mockito_version: '3.9.0'
 ]
 
 dependencies {
@@ -37,7 +38,9 @@ dependencies {
             "io.dropwizard:dropwizard-assets:${dependencyVersions.dropwizard}"
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:${dependencyVersions.junit_version}",
-        "io.dropwizard:dropwizard-testing:${dependencyVersions.dropwizard}"
+        "io.dropwizard:dropwizard-testing:${dependencyVersions.dropwizard}",
+            "org.mockito:mockito-core:${dependencyVersions.mockito_version}",
+            "org.mockito:mockito-junit-jupiter:${dependencyVersions.mockito_version}"
 
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${dependencyVersions.junit_version}"
 }

--- a/oidc-provider.yml
+++ b/oidc-provider.yml
@@ -4,3 +4,5 @@ server:
   connector:
     type: http
     port: 8080
+
+issuer: di-auth-oidc-provider

--- a/src/main/java/uk/gov/di/OidcProviderApplication.java
+++ b/src/main/java/uk/gov/di/OidcProviderApplication.java
@@ -8,6 +8,8 @@ import uk.gov.di.configuration.OidcProviderConfiguration;
 import io.dropwizard.Application;
 import uk.gov.di.resources.AuthorisationResource;
 import uk.gov.di.resources.LoginResource;
+import uk.gov.di.resources.TokenResource;
+import uk.gov.di.services.TokenService;
 
 public class OidcProviderApplication extends Application<OidcProviderConfiguration>{
     public static void main(String[] args) throws Exception {
@@ -32,5 +34,6 @@ public class OidcProviderApplication extends Application<OidcProviderConfigurati
     public void run(OidcProviderConfiguration configuration, Environment env) {
         env.jersey().register(new AuthorisationResource());
         env.jersey().register(new LoginResource());
+        env.jersey().register(new TokenResource(new TokenService(configuration)));
     }
 }

--- a/src/main/java/uk/gov/di/configuration/OidcProviderConfiguration.java
+++ b/src/main/java/uk/gov/di/configuration/OidcProviderConfiguration.java
@@ -1,7 +1,17 @@
 package uk.gov.di.configuration;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.Configuration;
+
+import javax.validation.constraints.NotNull;
 
 public class OidcProviderConfiguration extends Configuration {
 
+    @JsonProperty
+    @NotNull
+    private String issuer;
+
+    public String getIssuer() {
+        return issuer;
+    }
 }

--- a/src/main/java/uk/gov/di/resources/TokenResource.java
+++ b/src/main/java/uk/gov/di/resources/TokenResource.java
@@ -1,0 +1,43 @@
+package uk.gov.di.resources;
+
+import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.oauth2.sdk.AuthorizationCode;
+import com.nimbusds.oauth2.sdk.ParseException;
+import com.nimbusds.oauth2.sdk.token.AccessToken;
+import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
+import com.nimbusds.openid.connect.sdk.OIDCTokenResponse;
+import com.nimbusds.openid.connect.sdk.token.OIDCTokens;
+import uk.gov.di.services.TokenService;
+
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.FormParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+@Path("/token")
+public class TokenResource {
+
+    private TokenService tokenService;
+
+    public TokenResource(TokenService tokenService) {
+        this.tokenService = tokenService;
+    }
+
+    @POST
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getTokens(@FormParam("code") @NotNull AuthorizationCode code, @FormParam("client_id") @NotNull String clientId) throws ParseException {
+
+        AccessToken accessToken = new BearerAccessToken();
+        SignedJWT idToken = tokenService.generateIDToken(clientId);
+
+        OIDCTokens oidcTokens = new OIDCTokens(idToken, accessToken, null);
+        OIDCTokenResponse tokenResponse = new OIDCTokenResponse(oidcTokens);
+
+        return Response.ok(tokenResponse.toJSONObject()).build();
+    }
+}

--- a/src/main/java/uk/gov/di/services/TokenService.java
+++ b/src/main/java/uk/gov/di/services/TokenService.java
@@ -1,0 +1,71 @@
+package uk.gov.di.services;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.oauth2.sdk.ParseException;
+import com.nimbusds.oauth2.sdk.id.Audience;
+import com.nimbusds.oauth2.sdk.id.Issuer;
+import com.nimbusds.oauth2.sdk.id.Subject;
+import com.nimbusds.openid.connect.sdk.claims.IDTokenClaimsSet;
+import uk.gov.di.configuration.OidcProviderConfiguration;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.List;
+
+public class TokenService {
+
+    private OidcProviderConfiguration config;
+
+    public TokenService(OidcProviderConfiguration config) {
+        this.config = config;
+    }
+
+    public SignedJWT generateIDToken(String clientId) {
+        LocalDateTime localDateTime = LocalDateTime.now().plusMinutes(2);
+        Date expiryDate = Date.from(localDateTime.atZone(ZoneId.systemDefault()).toInstant());
+
+        IDTokenClaimsSet idTokenClaims = new IDTokenClaimsSet(
+                new Issuer(config.getIssuer()),
+                new Subject(),
+                List.of(new Audience(clientId)),
+                expiryDate,
+                new Date());
+
+        JWTClaimsSet jwtClaimsSet;
+        try {
+            jwtClaimsSet = idTokenClaims.toJWTClaimsSet();
+        } catch (ParseException e) {
+            throw new RuntimeException("Can't convert IDTokenClaimsSet to JWTClaimsSet");
+        }
+        RSAKey signingKey = createSigningKey();
+        JWSHeader jwsHeader = new JWSHeader.Builder(JWSAlgorithm.RS256).keyID(signingKey.getKeyID()).build();
+        SignedJWT idToken;
+
+        try {
+            JWSSigner signer = new RSASSASigner(signingKey);
+            idToken = new SignedJWT(jwsHeader, jwtClaimsSet);
+            idToken.sign(signer);
+        } catch (JOSEException e) {
+            throw new RuntimeException();
+        }
+
+        return idToken;
+    }
+
+    private RSAKey createSigningKey() {
+        try {
+            return new RSAKeyGenerator(2048).keyID("123").generate();
+        } catch (JOSEException e) {
+            throw new RuntimeException("Unable to create RSA key");
+        }
+    }
+}

--- a/src/test/java/uk/gov/di/TokenResourceTest.java
+++ b/src/test/java/uk/gov/di/TokenResourceTest.java
@@ -1,0 +1,42 @@
+package uk.gov.di;
+
+import com.nimbusds.jwt.SignedJWT;
+import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
+import io.dropwizard.testing.junit5.ResourceExtension;
+import org.eclipse.jetty.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import uk.gov.di.resources.TokenResource;
+import uk.gov.di.services.TokenService;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(DropwizardExtensionsSupport.class)
+public class TokenResourceTest {
+
+    private static final TokenService tokenService = mock(TokenService.class);
+    private static final SignedJWT signedJWT = mock(SignedJWT.class);
+    private static final ResourceExtension tokenResourceExtension = ResourceExtension.builder().addResource(new TokenResource(tokenService)).build();
+
+    @Test
+    public void testTokenResource() {
+        when(tokenService.generateIDToken(anyString())).thenReturn(signedJWT);
+
+        MultivaluedMap<String, String> tokenResourceFormParams = new MultivaluedHashMap<>();
+        tokenResourceFormParams.add("code", "123");
+        tokenResourceFormParams.add("client_id",  "123");
+
+        final Response response = tokenResourceExtension.target("/token").request()
+                .post(Entity.form(tokenResourceFormParams));
+
+        assertEquals(HttpStatus.OK_200, response.getStatus());
+    }
+}

--- a/src/test/resources/oidc-provider.yml
+++ b/src/test/resources/oidc-provider.yml
@@ -4,3 +4,5 @@ server:
   connector:
     type: http
     port: 8080
+
+issuer: di-auth-oidc-provider


### PR DESCRIPTION
- This PR adds a `/token` endpoint to the di-auth-oidc-provider. This endpoint returns a OIDCTokenResponse.
- The token endpoint expects a `client_id` and authorization code
- The bearer access token is created using the nimbus library
- We can create the ID token claim set using the nimbus library but we need to generate the header and signature of the ID token manually. To do this we generate a new signing key on the fly which will then sign the token. 
- Add an integration test to ensure the response is successful.

**TODO** 
- Validate the token request