### PR TITLE
BAU: add gradle task to push to paas

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,3 +57,9 @@ mainClassName = 'uk.gov.di.OidcProviderApplication'
 run {
     args = ['server', 'oidc-provider.yml']
 }
+
+task cfPush(type: Exec) {
+    commandLine 'cf', 'push', 'di-auth-oidc-provider', '-p', 'build/distributions/di-auth-oidc-provider.zip'
+}
+
+cfPush.dependsOn build


### PR DESCRIPTION
## What?

Add gradle task to push to PaaS.

## Why?

So you don't forget to compile if pushing manually