### PR TITLE
1WQSBhCg: Get client configuration from database

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,8 @@ def dependencyVersions = [
         nimbus_oauth2_sdk: '9.3.1',
         nimbus_jose_jwt: '9.8.1',
         junit_version: '5.6.0',
-        mockito_version: '3.9.0'
+        mockito_version: '3.9.0',
+        jdbi_version: '3.19.0'
 ]
 
 dependencies {
@@ -37,7 +38,8 @@ dependencies {
             "io.dropwizard:dropwizard-views-mustache:${dependencyVersions.dropwizard}",
             "io.dropwizard:dropwizard-assets:${dependencyVersions.dropwizard}",
             "io.dropwizard:dropwizard-jdbi3:${dependencyVersions.dropwizard}",
-            "org.postgresql:postgresql:42.2.19"
+            "org.jdbi:jdbi3-postgres:${dependencyVersions.jdbi_version}",
+            "org.jdbi:jdbi3-jackson2:${dependencyVersions.jdbi_version}"
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:${dependencyVersions.junit_version}",
         "io.dropwizard:dropwizard-testing:${dependencyVersions.dropwizard}",

--- a/sql/R__insert_client_configuration.sql
+++ b/sql/R__insert_client_configuration.sql
@@ -1,0 +1,4 @@
+INSERT INTO client ( client_id, client_secret, scopes, allowed_response_types, redirect_urls )
+VALUES ('some_client_id', 'password', '["openid", "profile", "email"]', '["code"]', '["https://di-auth-stub-relying-party.london.cloudapps.digital/oidc/callback", "http://localhost:8081/oidc/callback"]')
+ON CONFLICT (client_id) DO UPDATE SET client_secret = EXCLUDED.client_secret, scopes = EXCLUDED.scopes, allowed_response_types = EXCLUDED.allowed_response_types, redirect_urls = EXCLUDED.redirect_urls
+;

--- a/src/main/java/uk/gov/di/OidcProviderApplication.java
+++ b/src/main/java/uk/gov/di/OidcProviderApplication.java
@@ -8,6 +8,8 @@ import io.dropwizard.jdbi3.JdbiFactory;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.views.ViewBundle;
+import org.jdbi.v3.jackson2.Jackson2Plugin;
+import org.jdbi.v3.postgres.PostgresPlugin;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.di.configuration.OidcProviderConfiguration;
@@ -54,6 +56,8 @@ public class OidcProviderApplication extends Application<OidcProviderConfigurati
     public void run(OidcProviderConfiguration configuration, Environment env) {
         PostgresService postgresService = new PostgresService(configuration);
         var jdbiFactory = new JdbiFactory().build(env, configuration.getDatabase(), "postgresql");
+        jdbiFactory.installPlugin(new PostgresPlugin());
+        jdbiFactory.installPlugin(new Jackson2Plugin());
         var clientConfigService = new ClientConfigService(jdbiFactory);
         var clientService =
                 new ClientService(clientConfigService.getClients());

--- a/src/main/java/uk/gov/di/OidcProviderApplication.java
+++ b/src/main/java/uk/gov/di/OidcProviderApplication.java
@@ -56,16 +56,7 @@ public class OidcProviderApplication extends Application<OidcProviderConfigurati
         var jdbiFactory = new JdbiFactory().build(env, configuration.getDatabase(), "postgresql");
         var clientConfigService = new ClientConfigService(jdbiFactory);
         var clientService =
-                new ClientService(
-                        List.of(
-                                new Client(
-                                        "some_client_id",
-                                        "password",
-                                        List.of("openid", "profile", "email"),
-                                        List.of("code"),
-                                        List.of(
-                                                "https://di-auth-stub-relying-party.london.cloudapps.digital/oidc/callback",
-                                                "http://localhost:8081/oidc/callback"))));
+                new ClientService(clientConfigService.getClients());
         env.jersey().register(new AuthorisationResource(clientService));
         env.jersey().register(new LoginResource(new UserValidationService()));
         env.jersey().register(new UserInfoResource());

--- a/src/main/java/uk/gov/di/services/ClientConfigService.java
+++ b/src/main/java/uk/gov/di/services/ClientConfigService.java
@@ -1,6 +1,8 @@
 package uk.gov.di.services;
 
 import org.jdbi.v3.core.Jdbi;
+import uk.gov.di.entity.Client;
+import java.util.List;
 
 public class ClientConfigService {
 
@@ -8,5 +10,17 @@ public class ClientConfigService {
 
     public ClientConfigService(Jdbi database) {
         this.database = database;
+    }
+
+    public List<Client> getClients() {
+        return List.of(
+                new Client(
+                        "some_client_id",
+                        "password",
+                        List.of("openid", "profile", "email"),
+                        List.of("code"),
+                        List.of(
+                                "https://di-auth-stub-relying-party.london.cloudapps.digital/oidc/callback",
+                                "http://localhost:8081/oidc/callback")));
     }
 }


### PR DESCRIPTION
## What?

Add a SQL script to pre-populate client configuration in the database
Add code to ClientConfigService to read data from database.

## Why?

We want to read client configuration from a data store rather than have it hard-coded.

## Related PRs

#41 