### PR TITLE
ikXzZaOa: Enable provider to run against a local Postgres instance

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,8 @@ dependencies {
             "io.dropwizard:dropwizard-assets:${dependencyVersions.dropwizard}",
             "io.dropwizard:dropwizard-jdbi3:${dependencyVersions.dropwizard}",
             "org.jdbi:jdbi3-postgres:${dependencyVersions.jdbi_version}",
-            "org.jdbi:jdbi3-jackson2:${dependencyVersions.jdbi_version}"
+            "org.jdbi:jdbi3-jackson2:${dependencyVersions.jdbi_version}",
+            "org.postgresql:postgresql:42.2.19"
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:${dependencyVersions.junit_version}",
         "io.dropwizard:dropwizard-testing:${dependencyVersions.dropwizard}",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: '3.8'
+
+services:
+  op-db:
+    image: "postgres:11-alpine@sha256:d706b23c20bb63f9408281e35beef25c6c01ddcd4712bf50101595bc9cfa9c8a"
+    ports:
+      - 15432:5432
+    restart: on-failure
+    command: postgres -c listen_addresses='*'
+    environment:
+      POSTGRES_PASSWORD: pass
+      POSTGRES_USER: user
+      POSTGRES_DB: store
+    networks:
+      - op-net
+
+  psql:
+    image: "postgres:11-alpine@sha256:d706b23c20bb63f9408281e35beef25c6c01ddcd4712bf50101595bc9cfa9c8a"
+    command: psql
+    environment:
+      PGPASSWORD: pass
+      PGUSER: user
+      PGDATABASE: store
+      PGHOST: op-db
+      PGPORT: 5432
+    networks:
+      - op-net
+
+networks:
+  op-net:

--- a/oidc-provider.yml
+++ b/oidc-provider.yml
@@ -9,4 +9,6 @@ issuer: di-auth-oidc-provider
 
 database:
   driverClass: org.postgresql.Driver
-  url: ${DATABASE_URL:-localhost}
+  url: ${DATABASE_URL:-jdbc:postgresql://localhost:15432/store}
+  user: user
+  password: pass

--- a/startup.sh
+++ b/startup.sh
@@ -5,4 +5,7 @@ CONFIG_FILE=oidc-provider.yml
 
 ./gradlew installDist
 
+docker-compose down || true
+docker-compose up -d
+
 ./build/install/di-auth-oidc-provider/bin/di-auth-oidc-provider server $CONFIG_FILE


### PR DESCRIPTION
## What?

* Instance is provided by docker-compose
* Missing dependency (org.postgresql) was added for driver
* Default configuration user/pass/name added in manifest
