### PR TITLE
BAU: Wait for Postgres and use Flyway for migrations

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,11 +6,30 @@ services:
     ports:
       - 15432:5432
     restart: on-failure
+    healthcheck:
+      test: pg_isready
+      interval: 5s
+      timeout: 3m
     command: postgres -c listen_addresses='*'
     environment:
       POSTGRES_PASSWORD: pass
       POSTGRES_USER: user
       POSTGRES_DB: store
+    networks:
+      - op-net
+
+  flyway:
+    image: flyway/flyway:6.2.1@sha256:8718ddb67cbd8e2b77af0fe50db7ce05bb8d6ed2b2a5aea432b4062990170be2
+    environment:
+      FLYWAY_URL: jdbc:postgresql://op-db:5432/store
+      FLYWAY_USER: user
+      FLYWAY_PASSWORD: pass
+      FLYWAY_MIXED: "true"
+    volumes:
+      - ./sql:/flyway/sql
+    command:
+      ["migrate", "-locations=filesystem:/flyway/sql"]
+    restart: on-failure
     networks:
       - op-net
 

--- a/startup.sh
+++ b/startup.sh
@@ -1,11 +1,29 @@
 #!/usr/bin/env bash
 set -eu
 
-CONFIG_FILE=oidc-provider.yml
+function wait_for_docker_services() {
+  RUNNING=0
+  LOOP_COUNT=0
+  echo -n "Waiting for service(s) to become healthy ($*) ."
+  until [[ ${RUNNING} == $# || ${LOOP_COUNT} == 100 ]]; do
+    RUNNING=$(docker-compose ps -q "$@" | xargs docker inspect | jq -rc '[ .[] | select(.State.Health.Status == "healthy")] | length')
+    LOOP_COUNT=$((LOOP_COUNT + 1))
+    echo -n "."
+  done
+  if [[ ${LOOP_COUNT} == 100 ]]; then
+    echo "FAILED"
+    return 1
+  fi
+  echo " done!"
+  return 0
+}
 
 ./gradlew installDist
 
 docker-compose down || true
-docker-compose up -d
+docker-compose up -d op-db
 
-./build/install/di-auth-oidc-provider/bin/di-auth-oidc-provider server $CONFIG_FILE
+wait_for_docker_services op-db
+docker-compose run flyway
+
+./gradlew run


### PR DESCRIPTION
## What?

Add a wait for the Postgres healthcheck to pass before continuing.
Add Flyway in to docker-compose and run `flyway migrate` in `startup.sh` to ensure migrations are run.

## Why?

This makes it nice and easy to run the IDP locally without needing to manually apply SQL scripts.