### PR TITLE
ikXzZaOa: Read port as a String rather than an int

### DIFF
--- a/src/main/java/uk/gov/di/entity/VcapServices.java
+++ b/src/main/java/uk/gov/di/entity/VcapServices.java
@@ -21,7 +21,7 @@ public class VcapServices {
     public record Service(Credentials credentials) {}
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    public record Credentials(String host, int port, String name, String username, String password) {}
+    public record Credentials(String host, String port, String name, String username, String password) {}
 
     public static Optional<Credentials> readPostgresConfiguration(String vcapServices) {
         try {

--- a/src/test/java/uk/gov/di/entity/VcapServicesTest.java
+++ b/src/test/java/uk/gov/di/entity/VcapServicesTest.java
@@ -16,7 +16,7 @@ class VcapServicesTest {
                     "credentials": {
                         "name": "database-name",
                         "host": "database-host",
-                        "port": "1234",
+                        "port": 1234,
                         "username": "database-username",
                         "password": "database-password"
                     }
@@ -29,7 +29,7 @@ class VcapServicesTest {
 
         assertEquals(credentials.name(), "database-name");
         assertEquals(credentials.host(), "database-host");
-        assertEquals(credentials.port(), 1234);
+        assertEquals(credentials.port(), "1234");
         assertEquals(credentials.username(), "database-username");
         assertEquals(credentials.password(), "database-password");
     }
@@ -59,7 +59,7 @@ class VcapServicesTest {
                 "credentials": {
                     "name": "database-name",
                     "host": "database-host",
-                    "port": "1234",
+                    "port": 1234,
                     "username": "database-username",
                     "password": "database-password",
                     "some-other-field": "other-value"


### PR DESCRIPTION
MessageFormat.format splits thousands with commas, which is invalid for our port

