### PR TITLE
BAU: Use docker-compose Gradle plugin to simplify the startup script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .gradle/
 .idea/
 build/
+logs/

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,28 @@
+plugins {
+    id "com.avast.gradle.docker-compose" version "0.14.3"
+}
+
 apply plugin: 'java'
 apply plugin: 'application'
 apply plugin: 'idea'
+apply plugin: 'com.avast.gradle.docker-compose'
+
+dockerCompose {
+    buildBeforeUp = true
+    forceRecreate = true
+    startedServices = [
+            'op-db',
+            'flyway',
+    ]
+    def logDir = new File(project.buildDir, "logs")
+    if (!logDir.exists()) {
+        println("creating logs folder...")
+        logDir.mkdir()
+    }
+    captureContainersOutput = false
+    captureContainersOutputToFile = new File('logs', 'docker-compose-gradle.log')
+    projectName = "di-auth-oidc-provider"
+}
 
 group 'uk.gov.di'
 
@@ -70,3 +92,4 @@ task cfPush(type: Exec) {
 }
 
 cfPush.dependsOn build
+rootProject.dockerCompose.isRequiredBy(run)

--- a/startup.sh
+++ b/startup.sh
@@ -1,29 +1,6 @@
 #!/usr/bin/env bash
 set -eu
 
-function wait_for_docker_services() {
-  RUNNING=0
-  LOOP_COUNT=0
-  echo -n "Waiting for service(s) to become healthy ($*) ."
-  until [[ ${RUNNING} == $# || ${LOOP_COUNT} == 100 ]]; do
-    RUNNING=$(docker-compose ps -q "$@" | xargs docker inspect | jq -rc '[ .[] | select(.State.Health.Status == "healthy")] | length')
-    LOOP_COUNT=$((LOOP_COUNT + 1))
-    echo -n "."
-  done
-  if [[ ${LOOP_COUNT} == 100 ]]; then
-    echo "FAILED"
-    return 1
-  fi
-  echo " done!"
-  return 0
-}
-
 ./gradlew installDist
-
-docker-compose down || true
-docker-compose up -d op-db
-
-wait_for_docker_services op-db
-docker-compose run flyway
 
 ./gradlew run


### PR DESCRIPTION
## What?

Instead of using a nasty bash loop use the Avast Gradle plugin for docker-compose to start the database and run migration scripts.

## Why?

Using the Gradle plugin gives a cleaner startup script and makes it easier to start the app within a Gradle aware IDE.