### PR TITLE
aYkXL8o0: Add user backend in memory

### DIFF
--- a/src/main/java/uk/gov/di/OidcProviderApplication.java
+++ b/src/main/java/uk/gov/di/OidcProviderApplication.java
@@ -14,7 +14,6 @@ import org.jdbi.v3.postgres.PostgresPlugin;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.di.configuration.OidcProviderConfiguration;
-import uk.gov.di.entity.Client;
 import uk.gov.di.resources.AuthorisationResource;
 import uk.gov.di.resources.LoginResource;
 import uk.gov.di.resources.RegistrationResource;
@@ -24,9 +23,7 @@ import uk.gov.di.services.ClientConfigService;
 import uk.gov.di.services.ClientService;
 import uk.gov.di.services.PostgresService;
 import uk.gov.di.services.TokenService;
-import uk.gov.di.services.UserValidationService;
-
-import java.util.List;
+import uk.gov.di.services.UserService;
 
 public class OidcProviderApplication extends Application<OidcProviderConfiguration> {
 
@@ -64,7 +61,7 @@ public class OidcProviderApplication extends Application<OidcProviderConfigurati
         var clientService =
                 new ClientService(clientConfigService.getClients());
         env.jersey().register(new AuthorisationResource(clientService));
-        env.jersey().register(new LoginResource(new UserValidationService()));
+        env.jersey().register(new LoginResource(new UserService()));
         env.jersey().register(new UserInfoResource());
         env.jersey().register(new TokenResource(new TokenService(configuration), clientService));
         env.jersey().register(new RegistrationResource());

--- a/src/main/java/uk/gov/di/OidcProviderApplication.java
+++ b/src/main/java/uk/gov/di/OidcProviderApplication.java
@@ -60,11 +60,12 @@ public class OidcProviderApplication extends Application<OidcProviderConfigurati
         var clientConfigService = new ClientConfigService(jdbiFactory);
         var clientService =
                 new ClientService(clientConfigService.getClients());
+        var userService = new UserService();
         env.jersey().register(new AuthorisationResource(clientService));
-        env.jersey().register(new LoginResource(new UserService()));
+        env.jersey().register(new LoginResource(userService));
         env.jersey().register(new UserInfoResource());
         env.jersey().register(new TokenResource(new TokenService(configuration), clientService));
-        env.jersey().register(new RegistrationResource());
+        env.jersey().register(new RegistrationResource(userService));
         env.jersey().property(ServerProperties.LOCATION_HEADER_RELATIVE_URI_RESOLUTION_DISABLED, true);
     }
 }

--- a/src/main/java/uk/gov/di/resources/LoginResource.java
+++ b/src/main/java/uk/gov/di/resources/LoginResource.java
@@ -1,7 +1,7 @@
 package uk.gov.di.resources;
 
 import io.dropwizard.views.View;
-import uk.gov.di.services.UserValidationService;
+import uk.gov.di.services.UserService;
 import uk.gov.di.views.LoginView;
 import uk.gov.di.views.PasswordView;
 import uk.gov.di.views.SuccessfulLoginView;
@@ -24,10 +24,10 @@ import java.net.URI;
 @Path("/login")
 public class LoginResource {
 
-    private UserValidationService userValidationService;
+    private UserService userService;
 
-    public LoginResource(UserValidationService userValidationService) {
-        this.userValidationService = userValidationService;
+    public LoginResource(UserService userService) {
+        this.userService = userService;
     }
 
     @GET
@@ -40,7 +40,7 @@ public class LoginResource {
 
     @POST
     public Response login(@FormParam("authRequest") String authRequest, @FormParam("email") String email) {
-        if (userValidationService.userExists(email)) {
+        if (userService.userExists(email)) {
             return Response.ok(new PasswordView(authRequest, email)).build();
         }
         else {
@@ -60,7 +60,7 @@ public class LoginResource {
             @FormParam("authRequest") String authRequest,
             @FormParam("email") String email,
             @FormParam("password") String password) {
-        boolean isValid = userValidationService.isValidUser(email, password);
+        boolean isValid = userService.isValidUser(email, password);
 
         if (isValid) {
             return Response.ok(new SuccessfulLoginView(authRequest)).build();

--- a/src/main/java/uk/gov/di/resources/RegistrationResource.java
+++ b/src/main/java/uk/gov/di/resources/RegistrationResource.java
@@ -2,6 +2,7 @@ package uk.gov.di.resources;
 
 import io.dropwizard.views.View;
 import org.apache.http.HttpStatus;
+import uk.gov.di.services.UserService;
 import uk.gov.di.views.SetPasswordView;
 import uk.gov.di.views.SuccessfulRegistration;
 
@@ -20,6 +21,12 @@ import java.net.URI;
 @Path("/registration")
 public class RegistrationResource {
 
+    private UserService userService;
+
+    public RegistrationResource(UserService userService) {
+        this.userService = userService;
+    }
+
     @POST
     @Produces(MediaType.TEXT_HTML)
     public View setPassword(@FormParam("authRequest") String authRequest, @FormParam("email") @NotNull String email) {
@@ -34,6 +41,7 @@ public class RegistrationResource {
                                 @FormParam("password") @NotNull String password,
                                 @FormParam("password-confirm") @NotNull String passwordConfirm) {
         if (!password.isBlank() && password.equals(passwordConfirm)) {
+            userService.addUser(email, password);
             return Response.ok(new SuccessfulRegistration(authRequest)).build();
         } else {
             return Response.status(HttpStatus.SC_BAD_REQUEST).entity(new SetPasswordView(email, authRequest, true)).build();

--- a/src/main/java/uk/gov/di/services/UserService.java
+++ b/src/main/java/uk/gov/di/services/UserService.java
@@ -2,7 +2,7 @@ package uk.gov.di.services;
 
 import java.util.Map;
 
-public class UserValidationService {
+public class UserService {
 
     private final Map<String, String> credentialsMap = Map.of("joe.bloggs@digital.cabinet-office.gov.uk", "password");
 

--- a/src/main/java/uk/gov/di/services/UserService.java
+++ b/src/main/java/uk/gov/di/services/UserService.java
@@ -1,10 +1,11 @@
 package uk.gov.di.services;
 
+import java.util.HashMap;
 import java.util.Map;
 
 public class UserService {
 
-    private final Map<String, String> credentialsMap = Map.of("joe.bloggs@digital.cabinet-office.gov.uk", "password");
+    private final Map<String, String> credentialsMap = new HashMap<>(Map.of("joe.bloggs@digital.cabinet-office.gov.uk", "password"));
 
     public boolean userExists(String email) {
         return credentialsMap.containsKey(email);
@@ -12,5 +13,9 @@ public class UserService {
 
     public boolean isValidUser(String email, String password) {
         return credentialsMap.containsKey(email) && credentialsMap.get(email).equals(password);
+    }
+    
+    public void addUser(String email, String password) {
+        credentialsMap.put(email, password);
     }
 }

--- a/src/test/java/uk/gov/di/resources/LoginResourceTest.java
+++ b/src/test/java/uk/gov/di/resources/LoginResourceTest.java
@@ -10,7 +10,7 @@ import org.glassfish.jersey.client.ClientProperties;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import uk.gov.di.services.UserValidationService;
+import uk.gov.di.services.UserService;
 
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MultivaluedHashMap;
@@ -27,12 +27,12 @@ import static org.mockito.Mockito.when;
 @ExtendWith(DropwizardExtensionsSupport.class)
 public class LoginResourceTest {
 
-    private static final UserValidationService userValidationService =
-            mock(UserValidationService.class);
+    private static final UserService USER_SERVICE =
+            mock(UserService.class);
 
     private static final ResourceExtension loginResource =
             ResourceExtension.builder()
-                    .addResource(new LoginResource(userValidationService))
+                    .addResource(new LoginResource(USER_SERVICE))
                     .setClientConfigurator(
                             clientConfig -> {
                                 clientConfig.property(ClientProperties.FOLLOW_REDIRECTS, false);
@@ -45,12 +45,12 @@ public class LoginResourceTest {
 
     @BeforeAll
     static void setUp() {
-        when(userValidationService.isValidUser(anyString(), anyString())).thenReturn(false);
-        when(userValidationService.isValidUser(
+        when(USER_SERVICE.isValidUser(anyString(), anyString())).thenReturn(false);
+        when(USER_SERVICE.isValidUser(
                 eq("joe.bloggs@digital.cabinet-office.gov.uk"), eq("password")))
                 .thenReturn(true);
-        when(userValidationService.userExists(anyString())).thenReturn(false);
-        when(userValidationService.userExists(eq("joe.bloggs@digital.cabinet-office.gov.uk"))).thenReturn(true);
+        when(USER_SERVICE.userExists(anyString())).thenReturn(false);
+        when(USER_SERVICE.userExists(eq("joe.bloggs@digital.cabinet-office.gov.uk"))).thenReturn(true);
     }
 
     @Test

--- a/src/test/java/uk/gov/di/resources/RegistrationResourceTest.java
+++ b/src/test/java/uk/gov/di/resources/RegistrationResourceTest.java
@@ -9,6 +9,8 @@ import org.apache.http.HttpStatus;
 import org.glassfish.jersey.client.ClientProperties;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import uk.gov.di.services.UserService;
 
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MultivaluedHashMap;
@@ -17,13 +19,18 @@ import javax.ws.rs.core.Response;
 import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
 class RegistrationResourceTest {
 
+    private static final UserService USER_SERVICE = mock(UserService.class);
+
     private static final ResourceExtension REGISTRATION_RESOURCE =
             ResourceExtension.builder()
-                    .addResource(new RegistrationResource())
+                    .addResource(new RegistrationResource(USER_SERVICE))
                     .setClientConfigurator(
                             clientConfig -> {
                                 clientConfig.property(ClientProperties.FOLLOW_REDIRECTS, false);
@@ -36,9 +43,10 @@ class RegistrationResourceTest {
 
     @Test
     void shouldSucceedIfPasswordsMatch() {
-        Response response = setPasswordRequest("", "reallysecure1234", "reallysecure1234");
+        Response response = setPasswordRequest("newuser@example.com", "reallysecure1234", "reallysecure1234");
 
         assertEquals(HttpStatus.SC_OK, response.getStatus());
+        verify(USER_SERVICE).addUser(eq("newuser@example.com"), eq("reallysecure1234"));
     }
 
     @Test

--- a/src/test/java/uk/gov/di/services/UserServiceTest.java
+++ b/src/test/java/uk/gov/di/services/UserServiceTest.java
@@ -5,36 +5,36 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class UserValidationServiceTest {
+public class UserServiceTest {
 
-    private final UserValidationService userValidationService = new UserValidationService();
+    private final UserService userService = new UserService();
 
     @Test
     public void shouldValidateUserWithCorrectCredentials() {
         assertTrue(
-                userValidationService.isValidUser(
+                userService.isValidUser(
                         "joe.bloggs@digital.cabinet-office.gov.uk", "password"));
     }
 
     @Test
     public void shouldValidateUserWithUnknownUsername() {
-        assertFalse(userValidationService.isValidUser("unknown@nowhere", "password"));
+        assertFalse(userService.isValidUser("unknown@nowhere", "password"));
     }
 
     @Test
     public void shouldValidateUserWithWrongPassword() {
         assertFalse(
-                userValidationService.isValidUser(
+                userService.isValidUser(
                         "joe.bloggs@digital.cabinet-office.gov.uk", "badPassword"));
     }
 
     @Test
     public void shouldValidateThatUserExists() {
-        assertTrue(userValidationService.userExists("joe.bloggs@digital.cabinet-office.gov.uk"));
+        assertTrue(userService.userExists("joe.bloggs@digital.cabinet-office.gov.uk"));
     }
 
     @Test
     public void shouldValidateThatUserDoesNotExists() {
-        assertFalse(userValidationService.userExists("unknown@nowhere"));
+        assertFalse(userService.userExists("unknown@nowhere"));
     }
 }

--- a/src/test/java/uk/gov/di/services/UserServiceTest.java
+++ b/src/test/java/uk/gov/di/services/UserServiceTest.java
@@ -37,4 +37,11 @@ public class UserServiceTest {
     public void shouldValidateThatUserDoesNotExists() {
         assertFalse(userService.userExists("unknown@nowhere"));
     }
+
+    @Test
+    public void shouldValidateANewUser() {
+        userService.addUser("newuser@example.com", "1234");
+
+        assertTrue(userService.isValidUser("newuser@example.com", "1234"));
+    }
 }


### PR DESCRIPTION
## What?

Add a simple, in memory, user back end that stores users credentials as they complete registration journeys.

## Why?

To persist user data between journeys.