### PR TITLE
aYkXL8o0: Add map of user info

### DIFF
--- a/src/main/java/uk/gov/di/services/UserService.java
+++ b/src/main/java/uk/gov/di/services/UserService.java
@@ -1,11 +1,28 @@
 package uk.gov.di.services;
 
+import com.nimbusds.oauth2.sdk.id.Subject;
+import com.nimbusds.openid.connect.sdk.claims.Gender;
+import com.nimbusds.openid.connect.sdk.claims.UserInfo;
+
 import java.util.HashMap;
 import java.util.Map;
 
 public class UserService {
 
     private final Map<String, String> credentialsMap = new HashMap<>(Map.of("joe.bloggs@digital.cabinet-office.gov.uk", "password"));
+    private final Map<String, UserInfo> userInfoMap = new HashMap<>();
+
+
+    public UserService() {
+        UserInfo userInfo = new UserInfo(new Subject());
+        userInfo.setFamilyName("Bloggs");
+        userInfo.setGivenName("Joe");
+        userInfo.setEmailAddress("joe.bloggs@digital.cabinet-office.gov.uk");
+        userInfo.setGender(Gender.MALE);
+
+        userInfoMap.put("joe.bloggs@digital.cabinet-office.gov.uk", userInfo);
+    }
+
 
     public boolean userExists(String email) {
         return credentialsMap.containsKey(email);
@@ -17,5 +34,10 @@ public class UserService {
     
     public void addUser(String email, String password) {
         credentialsMap.put(email, password);
+
+        UserInfo userInfo = new UserInfo(new Subject());
+        userInfo.setEmailAddress(email);
+
+        userInfoMap.put(email, userInfo);
     }
 }


### PR DESCRIPTION
## What?

Create a map of `UserInfo` objects in the User Service

## Why?

We want to store user information collected during registration and have the `userinfo` endpoint return it rather than the current static values.