### PR TITLE
aYkXL8o0: TokenService now persists access tokens

### DIFF
--- a/src/main/java/uk/gov/di/services/TokenService.java
+++ b/src/main/java/uk/gov/di/services/TokenService.java
@@ -13,17 +13,22 @@ import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.oauth2.sdk.id.Audience;
 import com.nimbusds.oauth2.sdk.id.Issuer;
 import com.nimbusds.oauth2.sdk.id.Subject;
+import com.nimbusds.oauth2.sdk.token.AccessToken;
+import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import com.nimbusds.openid.connect.sdk.claims.IDTokenClaimsSet;
 import uk.gov.di.configuration.OidcProviderConfiguration;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class TokenService {
 
     private OidcProviderConfiguration config;
+    private final Map<AccessToken, String> tokensMap = new HashMap<>();
 
     public TokenService(OidcProviderConfiguration config) {
         this.config = config;
@@ -61,6 +66,17 @@ public class TokenService {
         }
 
         return idToken;
+    }
+
+    public AccessToken issueToken(String email) {
+        AccessToken accessToken = new BearerAccessToken();
+        tokensMap.put(accessToken, email);
+
+        return accessToken;
+    }
+
+    public String getEmailForToken(AccessToken token) {
+        return tokensMap.get(token);
     }
 
     private RSAKey createSigningKey() {

--- a/src/test/java/uk/gov/di/services/TokenServiceTest.java
+++ b/src/test/java/uk/gov/di/services/TokenServiceTest.java
@@ -1,0 +1,20 @@
+package uk.gov.di.services;
+
+import com.nimbusds.oauth2.sdk.token.AccessToken;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.configuration.OidcProviderConfiguration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TokenServiceTest {
+
+    private final TokenService tokenService = new TokenService(new OidcProviderConfiguration());
+
+    @Test
+    public void shouldAssociateCreatedTokenWithEmailAddress() {
+        AccessToken token = tokenService.issueToken("test@digital.cabinet-office.gov.uk");
+
+        assertEquals("test@digital.cabinet-office.gov.uk", tokenService.getEmailForToken(token));
+    }
+
+}


### PR DESCRIPTION
## What?

Store access tokens we issue and associate them with the correct user.

## Why?

This is another step along the way of ensuring that the `userinfo` endpoint returns the correct detail.

## Related PRs

#52 