### PR TITLE
aYkXL8o0: Add authorisation code service

### DIFF
--- a/src/main/java/uk/gov/di/OidcProviderApplication.java
+++ b/src/main/java/uk/gov/di/OidcProviderApplication.java
@@ -19,6 +19,7 @@ import uk.gov.di.resources.LoginResource;
 import uk.gov.di.resources.RegistrationResource;
 import uk.gov.di.resources.TokenResource;
 import uk.gov.di.resources.UserInfoResource;
+import uk.gov.di.services.AuthorizationCodeService;
 import uk.gov.di.services.ClientConfigService;
 import uk.gov.di.services.ClientService;
 import uk.gov.di.services.PostgresService;
@@ -58,8 +59,9 @@ public class OidcProviderApplication extends Application<OidcProviderConfigurati
         jdbiFactory.installPlugin(new PostgresPlugin());
         jdbiFactory.installPlugin(new Jackson2Plugin());
         var clientConfigService = new ClientConfigService(jdbiFactory);
+        var authorizationCodeService = new AuthorizationCodeService();
         var clientService =
-                new ClientService(clientConfigService.getClients());
+                new ClientService(clientConfigService.getClients(), authorizationCodeService);
         var userService = new UserService();
         env.jersey().register(new AuthorisationResource(clientService));
         env.jersey().register(new LoginResource(userService));

--- a/src/main/java/uk/gov/di/helpers/AuthenticationResponseHelper.java
+++ b/src/main/java/uk/gov/di/helpers/AuthenticationResponseHelper.java
@@ -10,10 +10,11 @@ import com.nimbusds.openid.connect.sdk.AuthenticationSuccessResponse;
 public class AuthenticationResponseHelper {
 
     public static AuthenticationResponse generateSuccessfulAuthResponse(
-            AuthorizationRequest authRequest) {
+            AuthorizationRequest authRequest,
+            AuthorizationCode authorizationCode) {
         return new AuthenticationSuccessResponse(
                 authRequest.getRedirectionURI(),
-                new AuthorizationCode(),
+                authorizationCode,
                 null,
                 null,
                 authRequest.getState(),

--- a/src/main/java/uk/gov/di/resources/AuthorisationResource.java
+++ b/src/main/java/uk/gov/di/resources/AuthorisationResource.java
@@ -1,9 +1,11 @@
 package uk.gov.di.resources;
 
+import com.nimbusds.oauth2.sdk.ErrorObject;
 import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import com.nimbusds.openid.connect.sdk.AuthenticationResponse;
 import org.eclipse.jetty.http.HttpStatus;
+import uk.gov.di.helpers.AuthenticationResponseHelper;
 import uk.gov.di.services.ClientService;
 
 import javax.ws.rs.CookieParam;
@@ -31,21 +33,24 @@ public class AuthorisationResource {
     @GET
     @Produces(MediaType.TEXT_HTML)
     public Response authorize(
-            @Context UriInfo uriInfo, @CookieParam("userCookie") Optional<String> username)
+            @Context UriInfo uriInfo, @CookieParam("userCookie") Optional<String> email)
             throws ParseException, RuntimeException {
-        boolean loggedIn = username.isPresent();
+        boolean loggedIn = email.isPresent();
 
         var authRequest = AuthenticationRequest.parse(uriInfo.getRequestUri());
 
-        AuthenticationResponse response = clientService.validateAuthorizationRequest(authRequest);
+        Optional<ErrorObject> error = clientService.getErrorForAuthorizationRequest(authRequest);
 
-        if (!response.indicatesSuccess()) {
+        if (error.isPresent()) {
+            AuthenticationResponse response = AuthenticationResponseHelper.generateErrorAuthnResponse(
+                    authRequest, error.get());
             return Response.status(HttpStatus.MOVED_TEMPORARILY_302)
                     .location(response.toErrorResponse().toURI())
                     .build();
         }
 
         if (loggedIn) {
+            AuthenticationResponse response = clientService.getSuccessfulResponse(authRequest, email.get());
             return Response.status(HttpStatus.MOVED_TEMPORARILY_302)
                     .location(response.toSuccessResponse().toURI())
                     .build();

--- a/src/main/java/uk/gov/di/services/AuthorizationCodeService.java
+++ b/src/main/java/uk/gov/di/services/AuthorizationCodeService.java
@@ -1,0 +1,24 @@
+package uk.gov.di.services;
+
+import com.nimbusds.oauth2.sdk.AuthorizationCode;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class AuthorizationCodeService {
+    private Map<AuthorizationCode, String> issuedCodes = new HashMap<>();
+
+    public AuthorizationCode issueCodeForUser(String email) {
+        AuthorizationCode authorizationCode = new AuthorizationCode();
+        issuedCodes.put(authorizationCode, email);
+
+        return authorizationCode;
+    }
+
+    public String getEmailForCode(AuthorizationCode authorizationCode) {
+        String email = issuedCodes.get(authorizationCode);
+        issuedCodes.remove(authorizationCode);
+
+        return email;
+    }
+}

--- a/src/main/java/uk/gov/di/services/ClientService.java
+++ b/src/main/java/uk/gov/di/services/ClientService.java
@@ -1,7 +1,10 @@
 package uk.gov.di.services;
 
+import com.nimbusds.oauth2.sdk.AuthorizationCode;
 import com.nimbusds.oauth2.sdk.AuthorizationRequest;
+import com.nimbusds.oauth2.sdk.ErrorObject;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
+import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import com.nimbusds.openid.connect.sdk.AuthenticationResponse;
 import com.nimbusds.openid.connect.sdk.OIDCError;
 import uk.gov.di.entity.Client;
@@ -13,37 +16,40 @@ import java.util.Optional;
 public class ClientService {
 
     private List<Client> clients;
+    private AuthorizationCodeService authorizationCodeService;
 
-    public ClientService(List<Client> clients) {
+    public ClientService(List<Client> clients, AuthorizationCodeService authorizationCodeService) {
         this.clients = clients;
+        this.authorizationCodeService = authorizationCodeService;
     }
 
-    public AuthenticationResponse validateAuthorizationRequest(AuthorizationRequest authRequest) {
+    public Optional<ErrorObject> getErrorForAuthorizationRequest(AuthorizationRequest authRequest) {
         Optional<Client> clientMaybe = getClient(authRequest.getClientID().toString());
 
         if (clientMaybe.isEmpty()) {
-            return AuthenticationResponseHelper.generateErrorAuthnResponse(
-                    authRequest, OIDCError.UNMET_AUTHENTICATION_REQUIREMENTS);
+            return Optional.of(OIDCError.UNMET_AUTHENTICATION_REQUIREMENTS);
         }
 
         var client = clientMaybe.get();
 
         if (!client.redirectUris().contains(authRequest.getRedirectionURI().toString())) {
-            return AuthenticationResponseHelper.generateErrorAuthnResponse(
-                    authRequest, OAuth2Error.INVALID_REQUEST_URI);
+            return Optional.of(OAuth2Error.INVALID_REQUEST_URI);
         }
 
         if (!client.allowedResponseTypes().contains(authRequest.getResponseType().toString())) {
-            return AuthenticationResponseHelper.generateErrorAuthnResponse(
-                    authRequest, OAuth2Error.UNSUPPORTED_RESPONSE_TYPE);
+            return Optional.of(OAuth2Error.UNSUPPORTED_RESPONSE_TYPE);
         }
 
         if (!client.scopes().containsAll(authRequest.getScope().toStringList())) {
-            return AuthenticationResponseHelper.generateErrorAuthnResponse(
-                    authRequest, OAuth2Error.INVALID_SCOPE);
+            return Optional.of(OAuth2Error.INVALID_SCOPE);
         }
 
-        return AuthenticationResponseHelper.generateSuccessfulAuthResponse(authRequest);
+        return Optional.empty();
+    }
+
+    public AuthenticationResponse getSuccessfulResponse(AuthenticationRequest authRequest, String email) {
+        AuthorizationCode code = authorizationCodeService.issueCodeForUser(email);
+        return AuthenticationResponseHelper.generateSuccessfulAuthResponse(authRequest, code);
     }
 
     public boolean isValidClient(String clientId, String clientSecret) {

--- a/src/test/java/uk/gov/di/services/AuthorizationCodeServiceTest.java
+++ b/src/test/java/uk/gov/di/services/AuthorizationCodeServiceTest.java
@@ -1,0 +1,26 @@
+package uk.gov.di.services;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class AuthorizationCodeServiceTest {
+
+    private static AuthorizationCodeService authorizationCodeService = new AuthorizationCodeService();
+
+    @Test
+    void shouldIssueAndStoreCodeForUser() {
+        var code = authorizationCodeService.issueCodeForUser("user@example.com");
+
+        assertEquals("user@example.com", authorizationCodeService.getEmailForCode(code));
+    }
+
+    @Test
+    void shouldOnlyAllowRetrievalOfCodeOnce() {
+        var code = authorizationCodeService.issueCodeForUser("user@example.com");
+
+        assertEquals("user@example.com", authorizationCodeService.getEmailForCode(code));
+        assertNull(authorizationCodeService.getEmailForCode(code));
+    }
+}


### PR DESCRIPTION
## What?

Implement a new service to issue and track authorisation codes and track them against the user.
Change the validateAuthenticationRequest method to check for, and return, errors in the authentication request.
Change the ClientService to use the AuthorisationCodeService to issue auth codes.

## Why?

This is another step along the way of ensuring that the `userinfo` endpoint returns the correct detail.

## Related PRs

#53 
#52
