### PR TITLE
aYkXL8o0: Store email address in cookie

### DIFF
--- a/src/main/java/uk/gov/di/resources/LoginResource.java
+++ b/src/main/java/uk/gov/di/resources/LoginResource.java
@@ -63,7 +63,18 @@ public class LoginResource {
         boolean isValid = userService.isValidUser(email, password);
 
         if (isValid) {
-            return Response.ok(new SuccessfulLoginView(authRequest)).build();
+            return Response.ok(new SuccessfulLoginView(authRequest))
+                    .cookie(
+                            new NewCookie(
+                                    "userCookie",
+                                    email,
+                                    "/",
+                                    null,
+                                    Cookie.DEFAULT_VERSION,
+                                    null,
+                                    NewCookie.DEFAULT_MAX_AGE,
+                                    false))
+                    .build();
         } else {
             URI destination =
                     UriBuilder.fromUri(URI.create("/login"))
@@ -80,16 +91,6 @@ public class LoginResource {
     public Response continueToAuthorize(@FormParam("authRequest") String authRequest) {
         return Response.status(Response.Status.FOUND)
                 .location(URI.create("/authorize?" + authRequest))
-                .cookie(
-                        new NewCookie(
-                                "userCookie",
-                                "dummy",
-                                "/",
-                                null,
-                                Cookie.DEFAULT_VERSION,
-                                null,
-                                NewCookie.DEFAULT_MAX_AGE,
-                                false))
                 .build();
     }
 }

--- a/src/main/java/uk/gov/di/resources/RegistrationResource.java
+++ b/src/main/java/uk/gov/di/resources/RegistrationResource.java
@@ -42,7 +42,18 @@ public class RegistrationResource {
                                 @FormParam("password-confirm") @NotNull String passwordConfirm) {
         if (!password.isBlank() && password.equals(passwordConfirm)) {
             userService.addUser(email, password);
-            return Response.ok(new SuccessfulRegistration(authRequest)).build();
+            return Response.ok(new SuccessfulRegistration(authRequest))
+                    .cookie(
+                            new NewCookie(
+                                    "userCookie",
+                                    email,
+                                    "/",
+                                    null,
+                                    Cookie.DEFAULT_VERSION,
+                                    null,
+                                    NewCookie.DEFAULT_MAX_AGE,
+                                    false))
+                    .build();
         } else {
             return Response.status(HttpStatus.SC_BAD_REQUEST).entity(new SetPasswordView(email, authRequest, true)).build();
         }
@@ -56,16 +67,6 @@ public class RegistrationResource {
             @FormParam("authRequest") String authRequest) {
         return Response.status(Response.Status.FOUND)
                 .location(URI.create("/authorize?" + authRequest))
-                .cookie(
-                        new NewCookie(
-                                "userCookie",
-                                "dummy",
-                                "/",
-                                null,
-                                Cookie.DEFAULT_VERSION,
-                                null,
-                                NewCookie.DEFAULT_MAX_AGE,
-                                false))
                 .build();
     }
 

--- a/src/test/java/uk/gov/di/resources/LoginResourceTest.java
+++ b/src/test/java/uk/gov/di/resources/LoginResourceTest.java
@@ -59,6 +59,7 @@ public class LoginResourceTest {
                 loginRequest("joe.bloggs@digital.cabinet-office.gov.uk", "password");
 
         assertEquals(HttpStatus.SC_OK, response.getStatus());
+        assertEquals("joe.bloggs@digital.cabinet-office.gov.uk", response.getCookies().get("userCookie").getValue());
     }
 
     @Test

--- a/src/test/java/uk/gov/di/resources/RegistrationResourceTest.java
+++ b/src/test/java/uk/gov/di/resources/RegistrationResourceTest.java
@@ -46,6 +46,7 @@ class RegistrationResourceTest {
         Response response = setPasswordRequest("newuser@example.com", "reallysecure1234", "reallysecure1234");
 
         assertEquals(HttpStatus.SC_OK, response.getStatus());
+        assertEquals("newuser@example.com", response.getCookies().get("userCookie").getValue());
         verify(USER_SERVICE).addUser(eq("newuser@example.com"), eq("reallysecure1234"));
     }
 


### PR DESCRIPTION
## What?

Temporarily store email address in cookie after successful login or registration (quick and dirty approach for the spike).

## Why?

So that the correct user will be stored against the authorisation code when it is issued.

## Related PRs

#52
#53
#54
