### PR TITLE
aYkXL8o0: Validate issuing of tokens against authorization codes

### DIFF
--- a/src/main/java/uk/gov/di/OidcProviderApplication.java
+++ b/src/main/java/uk/gov/di/OidcProviderApplication.java
@@ -66,7 +66,7 @@ public class OidcProviderApplication extends Application<OidcProviderConfigurati
         env.jersey().register(new AuthorisationResource(clientService));
         env.jersey().register(new LoginResource(userService));
         env.jersey().register(new UserInfoResource());
-        env.jersey().register(new TokenResource(new TokenService(configuration), clientService));
+        env.jersey().register(new TokenResource(new TokenService(configuration), clientService, authorizationCodeService));
         env.jersey().register(new RegistrationResource(userService));
         env.jersey().property(ServerProperties.LOCATION_HEADER_RELATIVE_URI_RESOLUTION_DISABLED, true);
     }

--- a/src/main/java/uk/gov/di/resources/TokenResource.java
+++ b/src/main/java/uk/gov/di/resources/TokenResource.java
@@ -4,7 +4,6 @@ import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
 import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.oauth2.sdk.token.AccessToken;
-import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import com.nimbusds.openid.connect.sdk.OIDCTokenResponse;
 import com.nimbusds.openid.connect.sdk.token.OIDCTokens;
 import org.apache.http.HttpStatus;
@@ -49,12 +48,11 @@ public class TokenResource {
 
         var email = authorizationCodeService.getEmailForCode(code);
 
-        if (email == null) {
+        if (email.isEmpty()) {
             return Response.status(HttpStatus.SC_FORBIDDEN).build();
         }
 
-        AccessToken accessToken = tokenService.issueToken(email);
-
+        AccessToken accessToken = tokenService.issueToken(email.get());
         SignedJWT idToken = tokenService.generateIDToken(clientId);
 
         OIDCTokens oidcTokens = new OIDCTokens(idToken, accessToken, null);

--- a/src/main/java/uk/gov/di/resources/TokenResource.java
+++ b/src/main/java/uk/gov/di/resources/TokenResource.java
@@ -7,6 +7,7 @@ import com.nimbusds.oauth2.sdk.token.AccessToken;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import com.nimbusds.openid.connect.sdk.OIDCTokenResponse;
 import com.nimbusds.openid.connect.sdk.token.OIDCTokens;
+import org.apache.http.HttpStatus;
 import uk.gov.di.services.AuthorizationCodeService;
 import uk.gov.di.services.ClientService;
 import uk.gov.di.services.TokenService;
@@ -47,6 +48,11 @@ public class TokenResource {
         }
 
         var email = authorizationCodeService.getEmailForCode(code);
+
+        if (email == null) {
+            return Response.status(HttpStatus.SC_FORBIDDEN).build();
+        }
+
         AccessToken accessToken = tokenService.issueToken(email);
 
         SignedJWT idToken = tokenService.generateIDToken(clientId);

--- a/src/main/java/uk/gov/di/resources/TokenResource.java
+++ b/src/main/java/uk/gov/di/resources/TokenResource.java
@@ -46,7 +46,9 @@ public class TokenResource {
             throw new RuntimeException("Bad authentication request");
         }
 
-        AccessToken accessToken = new BearerAccessToken();
+        var email = authorizationCodeService.getEmailForCode(code);
+        AccessToken accessToken = tokenService.issueToken(email);
+
         SignedJWT idToken = tokenService.generateIDToken(clientId);
 
         OIDCTokens oidcTokens = new OIDCTokens(idToken, accessToken, null);

--- a/src/main/java/uk/gov/di/resources/TokenResource.java
+++ b/src/main/java/uk/gov/di/resources/TokenResource.java
@@ -7,6 +7,7 @@ import com.nimbusds.oauth2.sdk.token.AccessToken;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import com.nimbusds.openid.connect.sdk.OIDCTokenResponse;
 import com.nimbusds.openid.connect.sdk.token.OIDCTokens;
+import uk.gov.di.services.AuthorizationCodeService;
 import uk.gov.di.services.ClientService;
 import uk.gov.di.services.TokenService;
 
@@ -22,12 +23,14 @@ import javax.ws.rs.core.Response;
 @Path("/token")
 public class TokenResource {
 
-    private TokenService tokenService;
+    private final TokenService tokenService;
     private final ClientService clientService;
+    private final AuthorizationCodeService authorizationCodeService;
 
-    public TokenResource(TokenService tokenService, ClientService clientService) {
+    public TokenResource(TokenService tokenService, ClientService clientService, AuthorizationCodeService authorizationCodeService) {
         this.tokenService = tokenService;
         this.clientService = clientService;
+        this.authorizationCodeService = authorizationCodeService;
     }
 
     @POST

--- a/src/main/java/uk/gov/di/services/AuthorizationCodeService.java
+++ b/src/main/java/uk/gov/di/services/AuthorizationCodeService.java
@@ -4,6 +4,7 @@ import com.nimbusds.oauth2.sdk.AuthorizationCode;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 public class AuthorizationCodeService {
     private Map<AuthorizationCode, String> issuedCodes = new HashMap<>();
@@ -15,10 +16,10 @@ public class AuthorizationCodeService {
         return authorizationCode;
     }
 
-    public String getEmailForCode(AuthorizationCode authorizationCode) {
+    public Optional<String> getEmailForCode(AuthorizationCode authorizationCode) {
         String email = issuedCodes.get(authorizationCode);
         issuedCodes.remove(authorizationCode);
 
-        return email;
+        return Optional.ofNullable(email);
     }
 }

--- a/src/test/java/uk/gov/di/resources/TokenResourceTest.java
+++ b/src/test/java/uk/gov/di/resources/TokenResourceTest.java
@@ -6,6 +6,7 @@ import io.dropwizard.testing.junit5.ResourceExtension;
 import org.eclipse.jetty.http.HttpStatus;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import uk.gov.di.services.AuthorizationCodeService;
 import uk.gov.di.services.ClientService;
 import uk.gov.di.services.TokenService;
 
@@ -23,11 +24,12 @@ import static org.mockito.Mockito.when;
 public class TokenResourceTest {
 
     private static final TokenService tokenService = mock(TokenService.class);
+    private static final AuthorizationCodeService authCodeService = mock(AuthorizationCodeService.class);
     private static final ClientService clientService = mock(ClientService.class);
     private static final SignedJWT signedJWT = mock(SignedJWT.class);
     private static final ResourceExtension tokenResourceExtension =
             ResourceExtension.builder()
-                    .addResource(new TokenResource(tokenService, clientService))
+                    .addResource(new TokenResource(tokenService, clientService, authCodeService))
                     .build();
 
     @Test

--- a/src/test/java/uk/gov/di/resources/TokenResourceTest.java
+++ b/src/test/java/uk/gov/di/resources/TokenResourceTest.java
@@ -59,6 +59,25 @@ public class TokenResourceTest {
     }
 
     @Test
+    public void shouldReturnForbiddenIfAuthorizationNotRecognised() {
+        when(authCodeService.getEmailForCode(eq(new AuthorizationCode("123")))).thenReturn(null);
+        when(clientService.isValidClient(anyString(), anyString())).thenReturn(true);
+
+        MultivaluedMap<String, String> tokenResourceFormParams = new MultivaluedHashMap<>();
+        tokenResourceFormParams.add("code", "123");
+        tokenResourceFormParams.add("client_id", "123");
+        tokenResourceFormParams.add("client_secret", "123");
+
+        final Response response =
+                tokenResourceExtension
+                        .target("/token")
+                        .request()
+                        .post(Entity.form(tokenResourceFormParams));
+
+        assertEquals(HttpStatus.FORBIDDEN_403, response.getStatus());
+    }
+
+    @Test
     public void shouldValidateClientCredentials() {
         when(clientService.isValidClient(anyString(), anyString())).thenReturn(false);
 

--- a/src/test/java/uk/gov/di/resources/TokenResourceTest.java
+++ b/src/test/java/uk/gov/di/resources/TokenResourceTest.java
@@ -1,6 +1,8 @@
 package uk.gov.di.resources;
 
 import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.oauth2.sdk.AuthorizationCode;
+import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import io.dropwizard.testing.junit5.ResourceExtension;
 import org.eclipse.jetty.http.HttpStatus;
@@ -17,6 +19,7 @@ import javax.ws.rs.core.Response;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -34,7 +37,11 @@ public class TokenResourceTest {
 
     @Test
     public void testTokenResource() {
+        var email = "joe.bloggs@digital.cabinet-office.gov.uk";
+
         when(tokenService.generateIDToken(anyString())).thenReturn(signedJWT);
+        when(tokenService.issueToken(email)).thenReturn(new BearerAccessToken());
+        when(authCodeService.getEmailForCode(eq(new AuthorizationCode("123")))).thenReturn(email);
         when(clientService.isValidClient(anyString(), anyString())).thenReturn(true);
 
         MultivaluedMap<String, String> tokenResourceFormParams = new MultivaluedHashMap<>();

--- a/src/test/java/uk/gov/di/resources/TokenResourceTest.java
+++ b/src/test/java/uk/gov/di/resources/TokenResourceTest.java
@@ -17,6 +17,8 @@ import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 
+import java.util.Optional;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -41,7 +43,7 @@ public class TokenResourceTest {
 
         when(tokenService.generateIDToken(anyString())).thenReturn(signedJWT);
         when(tokenService.issueToken(email)).thenReturn(new BearerAccessToken());
-        when(authCodeService.getEmailForCode(eq(new AuthorizationCode("123")))).thenReturn(email);
+        when(authCodeService.getEmailForCode(eq(new AuthorizationCode("123")))).thenReturn(Optional.of(email));
         when(clientService.isValidClient(anyString(), anyString())).thenReturn(true);
 
         MultivaluedMap<String, String> tokenResourceFormParams = new MultivaluedHashMap<>();
@@ -60,7 +62,7 @@ public class TokenResourceTest {
 
     @Test
     public void shouldReturnForbiddenIfAuthorizationNotRecognised() {
-        when(authCodeService.getEmailForCode(eq(new AuthorizationCode("123")))).thenReturn(null);
+        when(authCodeService.getEmailForCode(eq(new AuthorizationCode("123")))).thenReturn(Optional.empty());
         when(clientService.isValidClient(anyString(), anyString())).thenReturn(true);
 
         MultivaluedMap<String, String> tokenResourceFormParams = new MultivaluedHashMap<>();

--- a/src/test/java/uk/gov/di/services/AuthorizationCodeServiceTest.java
+++ b/src/test/java/uk/gov/di/services/AuthorizationCodeServiceTest.java
@@ -3,7 +3,7 @@ package uk.gov.di.services;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class AuthorizationCodeServiceTest {
 
@@ -13,14 +13,14 @@ class AuthorizationCodeServiceTest {
     void shouldIssueAndStoreCodeForUser() {
         var code = authorizationCodeService.issueCodeForUser("user@example.com");
 
-        assertEquals("user@example.com", authorizationCodeService.getEmailForCode(code));
+        assertEquals("user@example.com", authorizationCodeService.getEmailForCode(code).get());
     }
 
     @Test
     void shouldOnlyAllowRetrievalOfCodeOnce() {
         var code = authorizationCodeService.issueCodeForUser("user@example.com");
 
-        assertEquals("user@example.com", authorizationCodeService.getEmailForCode(code));
-        assertNull(authorizationCodeService.getEmailForCode(code));
+        assertEquals("user@example.com", authorizationCodeService.getEmailForCode(code).get());
+        assertTrue(authorizationCodeService.getEmailForCode(code).isEmpty());
     }
 }


### PR DESCRIPTION
## What?

Only permit tokens to be issued when requested with authentication codes that we have already issued.

## Why?

So people can't just claim tokens however they want.

