### PR TITLE
aYkXL8o0: Validate requests for UserInfo

### DIFF
--- a/src/main/java/uk/gov/di/OidcProviderApplication.java
+++ b/src/main/java/uk/gov/di/OidcProviderApplication.java
@@ -63,10 +63,12 @@ public class OidcProviderApplication extends Application<OidcProviderConfigurati
         var clientService =
                 new ClientService(clientConfigService.getClients(), authorizationCodeService);
         var userService = new UserService();
+        var tokenService = new TokenService(configuration);
+
         env.jersey().register(new AuthorisationResource(clientService));
         env.jersey().register(new LoginResource(userService));
-        env.jersey().register(new UserInfoResource());
-        env.jersey().register(new TokenResource(new TokenService(configuration), clientService, authorizationCodeService));
+        env.jersey().register(new UserInfoResource(tokenService));
+        env.jersey().register(new TokenResource(tokenService, clientService, authorizationCodeService));
         env.jersey().register(new RegistrationResource(userService));
         env.jersey().property(ServerProperties.LOCATION_HEADER_RELATIVE_URI_RESOLUTION_DISABLED, true);
     }

--- a/src/main/java/uk/gov/di/OidcProviderApplication.java
+++ b/src/main/java/uk/gov/di/OidcProviderApplication.java
@@ -67,7 +67,7 @@ public class OidcProviderApplication extends Application<OidcProviderConfigurati
 
         env.jersey().register(new AuthorisationResource(clientService));
         env.jersey().register(new LoginResource(userService));
-        env.jersey().register(new UserInfoResource(tokenService));
+        env.jersey().register(new UserInfoResource(tokenService, userService));
         env.jersey().register(new TokenResource(tokenService, clientService, authorizationCodeService));
         env.jersey().register(new RegistrationResource(userService));
         env.jersey().property(ServerProperties.LOCATION_HEADER_RELATIVE_URI_RESOLUTION_DISABLED, true);

--- a/src/main/java/uk/gov/di/resources/UserInfoResource.java
+++ b/src/main/java/uk/gov/di/resources/UserInfoResource.java
@@ -6,6 +6,7 @@ import com.nimbusds.oauth2.sdk.token.AccessToken;
 import com.nimbusds.openid.connect.sdk.claims.Gender;
 import com.nimbusds.openid.connect.sdk.claims.UserInfo;
 import org.apache.http.HttpStatus;
+import uk.gov.di.services.TokenService;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
@@ -16,6 +17,12 @@ import javax.ws.rs.core.Response;
 
 @Path("/userinfo")
 public class UserInfoResource {
+
+    private final TokenService tokenService;
+
+    public UserInfoResource(TokenService tokenService) {
+        this.tokenService = tokenService;
+    }
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)

--- a/src/main/java/uk/gov/di/resources/UserInfoResource.java
+++ b/src/main/java/uk/gov/di/resources/UserInfoResource.java
@@ -1,12 +1,10 @@
 package uk.gov.di.resources;
 
 import com.nimbusds.oauth2.sdk.ParseException;
-import com.nimbusds.oauth2.sdk.id.Subject;
 import com.nimbusds.oauth2.sdk.token.AccessToken;
-import com.nimbusds.openid.connect.sdk.claims.Gender;
-import com.nimbusds.openid.connect.sdk.claims.UserInfo;
 import org.apache.http.HttpStatus;
 import uk.gov.di.services.TokenService;
+import uk.gov.di.services.UserService;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
@@ -19,9 +17,11 @@ import javax.ws.rs.core.Response;
 public class UserInfoResource {
 
     private final TokenService tokenService;
+    private final UserService userService;
 
-    public UserInfoResource(TokenService tokenService) {
+    public UserInfoResource(TokenService tokenService, UserService userService) {
         this.tokenService = tokenService;
+        this.userService = userService;
     }
 
     @GET
@@ -31,11 +31,8 @@ public class UserInfoResource {
         try {
             AccessToken accessToken = AccessToken.parse(authorizationHeader);
 
-            UserInfo userInfo = new UserInfo(new Subject());
-            userInfo.setFamilyName("Bloggs");
-            userInfo.setGivenName("Joe");
-            userInfo.setEmailAddress("joe.bloggs@digital.cabinet-office.gov.uk");
-            userInfo.setGender(Gender.MALE);
+            var email = tokenService.getEmailForToken(accessToken);
+            var userInfo = userService.getInfoForEmail(email);
 
             return Response.ok(userInfo.toJSONObject()).build();
         } catch (ParseException e) {

--- a/src/main/java/uk/gov/di/services/UserService.java
+++ b/src/main/java/uk/gov/di/services/UserService.java
@@ -12,7 +12,6 @@ public class UserService {
     private final Map<String, String> credentialsMap = new HashMap<>(Map.of("joe.bloggs@digital.cabinet-office.gov.uk", "password"));
     private final Map<String, UserInfo> userInfoMap = new HashMap<>();
 
-
     public UserService() {
         UserInfo userInfo = new UserInfo(new Subject());
         userInfo.setFamilyName("Bloggs");
@@ -39,5 +38,9 @@ public class UserService {
         userInfo.setEmailAddress(email);
 
         userInfoMap.put(email, userInfo);
+    }
+
+    public UserInfo getInfoForEmail(String email) {
+        return userInfoMap.get(email);
     }
 }

--- a/src/test/java/uk/gov/di/resources/UserInfoResourceTest.java
+++ b/src/test/java/uk/gov/di/resources/UserInfoResourceTest.java
@@ -5,17 +5,20 @@ import io.dropwizard.testing.junit5.ResourceExtension;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import uk.gov.di.services.TokenService;
 
 import javax.ws.rs.core.Response;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
 class UserInfoResourceTest {
 
+    private static final TokenService tokenService = mock(TokenService.class);
     private static final ResourceExtension userInfoExtension =
-            ResourceExtension.builder().addResource(new UserInfoResource()).build();
+            ResourceExtension.builder().addResource(new UserInfoResource(tokenService)).build();
 
     @Test
     void shouldReturnUnauthorisedIfNoHeaderPresent() {

--- a/src/test/java/uk/gov/di/services/UserServiceTest.java
+++ b/src/test/java/uk/gov/di/services/UserServiceTest.java
@@ -1,7 +1,9 @@
 package uk.gov.di.services;
 
+import com.nimbusds.openid.connect.sdk.claims.Gender;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -43,5 +45,15 @@ public class UserServiceTest {
         userService.addUser("newuser@example.com", "1234");
 
         assertTrue(userService.isValidUser("newuser@example.com", "1234"));
+    }
+
+    @Test
+    public void shouldRetrieveUserInfoForEmail() {
+        var userInfo = userService.getInfoForEmail("joe.bloggs@digital.cabinet-office.gov.uk");
+
+        assertEquals(userInfo.getFamilyName(), "Bloggs");
+        assertEquals(userInfo.getGivenName(), "Joe");
+        assertEquals(userInfo.getEmailAddress(), "joe.bloggs@digital.cabinet-office.gov.uk");
+        assertEquals(userInfo.getGender(), Gender.MALE);
     }
 }


### PR DESCRIPTION
## What?

Only allow UserInfo requests that have a recognised access token

## Why?

Don't want people querying user info if they don't have permission for it.
