### PR TITLE
XytEISqB: Add a logout endpoint

### DIFF
--- a/src/main/java/uk/gov/di/OidcProviderApplication.java
+++ b/src/main/java/uk/gov/di/OidcProviderApplication.java
@@ -16,6 +16,7 @@ import org.slf4j.LoggerFactory;
 import uk.gov.di.configuration.OidcProviderConfiguration;
 import uk.gov.di.resources.AuthorisationResource;
 import uk.gov.di.resources.LoginResource;
+import uk.gov.di.resources.LogoutResource;
 import uk.gov.di.resources.RegistrationResource;
 import uk.gov.di.resources.TokenResource;
 import uk.gov.di.resources.UserInfoResource;
@@ -70,6 +71,7 @@ public class OidcProviderApplication extends Application<OidcProviderConfigurati
         env.jersey().register(new UserInfoResource(tokenService, userService));
         env.jersey().register(new TokenResource(tokenService, clientService, authorizationCodeService));
         env.jersey().register(new RegistrationResource(userService));
+        env.jersey().register(new LogoutResource());
         env.jersey().property(ServerProperties.LOCATION_HEADER_RELATIVE_URI_RESOLUTION_DISABLED, true);
     }
 }

--- a/src/main/java/uk/gov/di/resources/LogoutResource.java
+++ b/src/main/java/uk/gov/di/resources/LogoutResource.java
@@ -1,0 +1,37 @@
+package uk.gov.di.resources;
+
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Cookie;
+import javax.ws.rs.core.NewCookie;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+import java.net.URI;
+
+@Path("/logout")
+public class LogoutResource {
+
+    @GET
+    public Response logout(@QueryParam("redirectUri") @NotNull String redirectUri) {
+        URI destination =
+                UriBuilder.fromUri(URI.create(redirectUri))
+                        .build();
+
+        return Response
+                .status(302)
+                .location(destination)
+                .cookie(
+                        new NewCookie(
+                                "userCookie",
+                                "",
+                                "/",
+                                null,
+                                Cookie.DEFAULT_VERSION,
+                                null,
+                                0,
+                                false))
+                .build();
+    }
+}


### PR DESCRIPTION
## What?

Add logout endpoint that will expire the cookie so that journeys can be re-run.

## Why?

We would like to be able to logout from the services while demo-ing journeys. We will add a link to the endpoint on the stub RP.