### PR TITLE
BAU: add startup.sh switch to enable cognito

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -1,10 +1,27 @@
 #!/usr/bin/env bash
 set -eu
 
-echo "Authenticating to AWS account digital-identity-dev using gds-users for Cognito access..."
+USE_COGNITO=0
+while [[ $# -gt 0 ]]; do
+  case $1 in
+  --cognito)
+    USE_COGNITO=1
+    ;;
+  --user)
+    USE_COGNITO=0
+    ;;
+  esac
+  shift
+done
 
-# Populate AWS credentials in environment variables to call Cognito
-eval $(gds-cli aws digital-identity-dev -e)
+if [[ ${USE_COGNITO} == "1" ]]; then
+  echo "Authenticating to AWS account digital-identity-dev using gds-users for Cognito access..."
+  # Populate AWS credentials in environment variables to call Cognito
+  eval $(gds-cli aws digital-identity-dev -e)
+  export AUTHENTICATION_SERVICE_PROVIDER=cognito
+else
+  export AUTHENTICATION_SERVICE_PROVIDER=user
+fi
 
 ./gradlew installDist
 


### PR DESCRIPTION
## What?

Add startup.sh switch to enable Cognito.

## Why?

Only want to authenticate to AWS if testing against Cognito.
Stop the AWS login dialog from appearing when it's not needed.
