### PR TITLE
BAU: Enable JVM debugger when running application.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,6 +87,12 @@ mainClassName = 'uk.gov.di.OidcProviderApplication'
 
 run {
     args = ['server', 'oidc-provider.yml']
+    debugOptions {
+        enabled = true
+        port = 8082
+        server = true
+        suspend = false
+    }
 }
 
 task cfPush(type: Exec) {


### PR DESCRIPTION
## What?

Enable JVM debugger when running application.

## Why?

Useful when debugging applications.
