### PR TITLE
BAU: use gov-uk fonts where missing

### DIFF
--- a/src/main/resources/uk/gov/di/views/confirm-registration.mustache
+++ b/src/main/resources/uk/gov/di/views/confirm-registration.mustache
@@ -13,7 +13,7 @@
 
                 <br />
 
-                <p>
+                <p class="govuk-body">
                     A GOV.UK Account will:
                 </p>
 

--- a/src/main/resources/uk/gov/di/views/login.mustache
+++ b/src/main/resources/uk/gov/di/views/login.mustache
@@ -24,7 +24,7 @@
                 <div class="govuk-inset-text">
                     A GOV.UK Account is separate from other government accounts (for example a personal tax account or Government Gateway).<br><!-- A GOV.UK Account will become the single sign-on for all of government. -->
                 </div>
-                <p>A GOV.UK Account will:</p>
+                <p class="govuk-body">A GOV.UK Account will:</p>
                 <ul class="govuk-list govuk-list--bullet">
                     <li>
                         let you reuse and share your data to ensure that government services are quicker to interact with

--- a/src/main/resources/uk/gov/di/views/set-password.mustache
+++ b/src/main/resources/uk/gov/di/views/set-password.mustache
@@ -56,9 +56,9 @@
                         Agree to our terms of use
                     </h3>
 
-                    <p>We will collect and save your information securely. We will not share your personal information without your consent.</p>
+                    <p class="govuk-body-s">We will collect and save your information securely. We will not share your personal information without your consent.</p>
 
-                    <p>By continuing, you confirm that you agree to our <a href="#">privacy notice</a> and our <a href="#">terms and conditions</a>.</p>
+                    <p class="govuk-body-s">By continuing, you confirm that you agree to our <a href="#">privacy notice</a> and our <a href="#">terms and conditions</a>.</p>
 
                     <button class="govuk-button" data-module="govuk-button">
                         Continue

--- a/src/main/resources/uk/gov/di/views/successful-registration.mustache
+++ b/src/main/resources/uk/gov/di/views/successful-registration.mustache
@@ -13,7 +13,7 @@
 
                 <br />
 
-                <p>
+                <p class="govuk-body">
                     A GOV.UK Account will:
                 </p>
 


### PR DESCRIPTION
## What?

Use gov-uk fonts where missing.

## Why?

Paragraph fonts not using standard gov-uk fonts in some places as per the design system.
