### PR TITLE
BAU - Refactor use of isPresent

### DIFF
--- a/src/main/java/uk/gov/di/services/ClientService.java
+++ b/src/main/java/uk/gov/di/services/ClientService.java
@@ -55,7 +55,8 @@ public class ClientService {
 
     public boolean isValidClient(String clientId, String clientSecret) {
         Optional<Client> client = getClient(clientId);
-        return client.isPresent() && client.get().clientSecret().equals(clientSecret);
+        return client.map(c -> c.clientSecret().equals(clientSecret))
+                .orElse(false);
     }
 
     private Optional<Client> getClient(String clientId) {


### PR DESCRIPTION
## What?

- Refactor use of isPresent


## Why?

- We can avoid using isPresent by attempting to map it to what we require and if that doesn't exist then return the alternative response. This follows what is recommended in the GDS way java style guide https://gds-way.cloudapps.digital/manuals/programming-languages/java.html#optionals

