### PR TITLE
BAU: use consistent naming for views

### DIFF
--- a/src/main/java/uk/gov/di/resources/RegistrationResource.java
+++ b/src/main/java/uk/gov/di/resources/RegistrationResource.java
@@ -5,9 +5,9 @@ import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.di.services.AuthenticationService;
-import uk.gov.di.views.ConfirmRegistration;
+import uk.gov.di.views.ConfirmRegistrationView;
 import uk.gov.di.views.SetPasswordView;
-import uk.gov.di.views.SuccessfulRegistration;
+import uk.gov.di.views.SuccessfulRegistrationView;
 import uk.gov.di.views.VerificationResponseView;
 
 import javax.validation.constraints.NotNull;
@@ -53,9 +53,9 @@ public class RegistrationResource {
         if (!password.isBlank() && password.equals(passwordConfirm)) {
             authenticationService.signUp(email, password);
             if (authenticationService.isEmailVerificationRequired()) {
-                return Response.ok(new ConfirmRegistration(authRequest, email)).build();
+                return Response.ok(new ConfirmRegistrationView(authRequest, email)).build();
             } else {
-                return Response.ok(new SuccessfulRegistration(authRequest))
+                return Response.ok(new SuccessfulRegistrationView(authRequest))
                         .cookie(
                                 new NewCookie(
                                         "userCookie",

--- a/src/main/java/uk/gov/di/views/ConfirmRegistrationView.java
+++ b/src/main/java/uk/gov/di/views/ConfirmRegistrationView.java
@@ -2,12 +2,12 @@ package uk.gov.di.views;
 
 import io.dropwizard.views.View;
 
-public class ConfirmRegistration extends View {
+public class ConfirmRegistrationView extends View {
 
     private String authRequest;
     private String email;
 
-    public ConfirmRegistration(String authRequest, String email) {
+    public ConfirmRegistrationView(String authRequest, String email) {
         super("confirm-registration.mustache");
         this.authRequest = authRequest;
         this.email = email;

--- a/src/main/java/uk/gov/di/views/SuccessfulRegistrationView.java
+++ b/src/main/java/uk/gov/di/views/SuccessfulRegistrationView.java
@@ -2,11 +2,11 @@ package uk.gov.di.views;
 
 import io.dropwizard.views.View;
 
-public class SuccessfulRegistration extends View {
+public class SuccessfulRegistrationView extends View {
 
     private String authRequest;
 
-    public SuccessfulRegistration(String authRequest) {
+    public SuccessfulRegistrationView(String authRequest) {
         super("successful-registration.mustache");
         this.authRequest = authRequest;
     }


### PR DESCRIPTION
## What?

Use consistent naming for views.

## Why?

All should have a 'View' suffix.
