### PR TITLE
LaFbWXIf: Add RESTful endpoint for client registration.

### DIFF
--- a/src/main/java/uk/gov/di/entity/Client.java
+++ b/src/main/java/uk/gov/di/entity/Client.java
@@ -1,14 +1,16 @@
 package uk.gov.di.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.jdbi.v3.json.Json;
 
 import java.util.List;
 
 public record Client(
-        String clientName,
-        String clientId,
-        String clientSecret,
-        @Json List<String> scopes,
-        @Json List<String> allowedResponseTypes,
-        @Json List<String> redirectUrls,
-        @Json List<String> contacts) {}
+        @JsonProperty("client_name") String clientName,
+        @JsonProperty("client_id") String clientId,
+        @JsonProperty("client_secret") String clientSecret,
+        @JsonProperty("scopes") @Json List<String> scopes,
+        @JsonIgnore @Json List<String> allowedResponseTypes,
+        @JsonProperty("redirect_uris") @Json List<String> redirectUrls,
+        @JsonProperty("contacts") @Json List<String> contacts) {}

--- a/src/main/java/uk/gov/di/entity/ClientRegistrationRequest.java
+++ b/src/main/java/uk/gov/di/entity/ClientRegistrationRequest.java
@@ -1,0 +1,15 @@
+package uk.gov.di.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.jdbi.v3.json.Json;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record ClientRegistrationRequest(
+        @JsonProperty("client_name") String clientName,
+        @JsonProperty("redirect_uris") List<String> redirectUris,
+        @JsonProperty("contacts") List<String> contacts
+) {
+}

--- a/src/main/java/uk/gov/di/resources/ClientRegistrationResource.java
+++ b/src/main/java/uk/gov/di/resources/ClientRegistrationResource.java
@@ -1,30 +1,30 @@
 package uk.gov.di.resources;
 
 import com.nimbusds.oauth2.sdk.AuthorizationRequest;
+import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.oauth2.sdk.ResponseType;
 import com.nimbusds.oauth2.sdk.Scope;
+import com.nimbusds.oauth2.sdk.client.ClientRegistrationResponse;
+import com.nimbusds.oauth2.sdk.http.HTTPResponse;
 import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.oauth2.sdk.id.State;
 import io.dropwizard.views.View;
 import org.apache.http.HttpStatus;
 import uk.gov.di.configuration.OidcProviderConfiguration;
 import uk.gov.di.entity.Client;
+import uk.gov.di.entity.ClientRegistrationRequest;
 import uk.gov.di.services.ClientService;
 import uk.gov.di.views.ClientNotAuthorisedView;
 import uk.gov.di.views.ClientRegistrationView;
 import uk.gov.di.views.SuccessfulClientRegistrationView;
 
 import javax.validation.constraints.NotEmpty;
-import javax.ws.rs.CookieParam;
-import javax.ws.rs.FormParam;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
+import javax.ws.rs.*;
 import javax.ws.rs.core.Cookie;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.NewCookie;
 import javax.ws.rs.core.Response;
+import java.io.IOException;
 import java.net.URI;
 import java.util.List;
 import java.util.Optional;
@@ -77,11 +77,22 @@ public class ClientRegistrationResource {
         return Response.status(HttpStatus.SC_UNAUTHORIZED).entity(new ClientNotAuthorisedView()).build();
     }
 
+    @POST
+    @Path("/register")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Response clientRegistrationJson(ClientRegistrationRequest clientRegistrationRequest) {
+        Client client = clientService.addClient(
+                clientRegistrationRequest.clientName(),
+                clientRegistrationRequest.redirectUris(),
+                clientRegistrationRequest.contacts());
+        return Response.ok(client).build();
+    }
+
     @GET
     @Path("/notauthorised")
     @Produces(MediaType.TEXT_HTML)
     public View clientRegistration() {
-
         return new ClientNotAuthorisedView();
     }
 

--- a/src/test/java/uk/gov/di/resources/ClientRegistrationResourceTest.java
+++ b/src/test/java/uk/gov/di/resources/ClientRegistrationResourceTest.java
@@ -10,6 +10,8 @@ import org.glassfish.jersey.client.ClientProperties;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import uk.gov.di.configuration.OidcProviderConfiguration;
+import uk.gov.di.entity.Client;
+import uk.gov.di.entity.ClientRegistrationRequest;
 import uk.gov.di.services.ClientConfigService;
 import uk.gov.di.services.ClientService;
 
@@ -20,8 +22,10 @@ import javax.ws.rs.core.Response;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -95,5 +99,24 @@ class ClientRegistrationResourceTest {
                 .get();
 
         assertEquals(HttpStatus.SC_OK, response.getStatus());
+    }
+
+    @Test
+    void shouldReturnSuccessfulRestfulResponse() {
+        ClientRegistrationRequest request = new ClientRegistrationRequest(
+                "restful_test_client",
+                List.of("http://example.com"),
+                List.of("contact@example.com")
+        );
+        final Response response = CLIENT_REGISTRATION_RESOURCE
+                .target("/connect/register")
+                .request()
+                .post(Entity.json(request));
+
+        assertEquals(HttpStatus.SC_OK, response.getStatus());
+        Client client = response.readEntity(Client.class);
+        assertEquals("restful_test_client", client.clientName());
+        assertNotNull(client.clientId());
+        assertNotNull(client.clientSecret());
     }
 }


### PR DESCRIPTION
## What?

Add an endpoint at `/register/connect` that accepts a `ClientRegistrationRequest` object.
Do not validate any access tokens.

## Why?

Adds an alternative method for dynamic client registration.

## Related PRs

#68 