### PR TITLE
dockerfile: Adding a dockerfile for easy building and running

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+Dockerfile*
+docker-compose*
+.dockerignore
+.git/
+.gitignore
+README.md
+*.sh
+ci/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM gradle:jdk16@sha256:d31e12d105e332ec2ef1f31c20eac6d1467295487ac70e534e3c1d0ae4a0506e AS build
+COPY --chown=gradle:gradle . /home/gradle/src
+WORKDIR /home/gradle/src
+RUN gradle build --no-daemon
+
+FROM openjdk:16-slim@sha256:38f6c41a7f4901b734f4a7cfc0daa6a1995b552d7ec9517496788f6cc8090235
+
+ENV PORT 8080
+RUN addgroup --system --gid 1001 appgroup && adduser --system --uid 1001 appuser --gid 1001
+RUN mkdir /app
+
+COPY --from=build \
+	/home/gradle/src/build/distributions/src.tar \
+	/home/gradle/src/oidc-provider.yml \
+	/app/
+
+WORKDIR /app
+RUN tar -xvf src.tar \
+	&& rm src.tar
+
+RUN chown -R appuser:appgroup /app/
+USER appuser
+EXPOSE $PORT
+
+ENTRYPOINT ["./src/bin/src", "server", "oidc-provider.yml"]
+LABEL project="di-auth-oidc-provider"


### PR DESCRIPTION
## What?

- Created dockerfile to build and run a di-auth-oidc-provider image.
- Added a .dockerignore file to ignore some files.

## Why?

Adding a dockerfile to allow easy cross collaboration between teams by allowing other teams to build and run the `di-auth-oidc-provider` project locally.