### PR TITLE
BAU - Add grant_types_supported to the well known endpoint

### DIFF
--- a/src/main/java/uk/gov/di/resources/WellKnownResource.java
+++ b/src/main/java/uk/gov/di/resources/WellKnownResource.java
@@ -115,6 +115,7 @@ public class WellKnownResource {
                 "zoneinfo"
             ],
             "claims_parameter_supported": true,
+            "grant_types_supported": ["authorization_code"],
             "service_documentation": "http://di-auth-oidc-provider.london.cloudapps.digitalservice/_documentation.html",
             "ui_locales_supported": [
                 "en-US",


### PR DESCRIPTION
## What?

- The python lib expects there to be a grant_types_supported in the well known endpoint, even though it is optional in the spec

## Why?

- The python lib expects that to exist

