### PR TITLE
BAU - Add redirect URI for Python Client

### DIFF
--- a/sql/R__insert_client_configuration.sql
+++ b/sql/R__insert_client_configuration.sql
@@ -1,6 +1,6 @@
 INSERT INTO client (client_name, client_id, client_secret, scopes, allowed_response_types, redirect_urls, contacts )
 VALUES
-    ('Dummy Service', 'some_client_id', 'password', '["openid", "profile", "email"]', '["code"]', '["https://di-auth-stub-relying-party.london.cloudapps.digital/oidc/callback", "http://localhost:8081/oidc/callback", "https://localhost:5001/signin-oidc", "http://localhost:8082/login/oauth2/code/custom"]', '["test@test.digital.cabinet-office.gov.uk"]'),
+    ('Dummy Service', 'some_client_id', 'password', '["openid", "profile", "email"]', '["code"]', '["https://di-auth-stub-relying-party.london.cloudapps.digital/oidc/callback", "http://localhost:8081/oidc/callback", "https://localhost:5001/signin-oidc", "http://localhost:8082/login/oauth2/code/custom", "http://localhost:5000/callback]', '["test@test.digital.cabinet-office.gov.uk"]'),
     ('Client Registration Service', 'admin_client_id', 'admin_client_secret', '["openid", "profile", "email"]', '["code"]', '["https://di-auth-oidc-provider.london.cloudapps.digital/client/callback", "http://localhost:8080/client/callback"]', '["test@test.digital.cabinet-office.gov.uk"]')
 ON CONFLICT (client_id) DO UPDATE SET client_name = EXCLUDED.client_name, client_secret = EXCLUDED.client_secret, scopes = EXCLUDED.scopes, allowed_response_types = EXCLUDED.allowed_response_types, redirect_urls = EXCLUDED.redirect_urls, contacts = EXCLUDED.contacts
 ;


### PR DESCRIPTION
## What?

- Add redirect URI for Python Client

## Why?

- So the Python client can use the Dummy service credentials

