### PR TITLE
BAU: Add script to aid applying Postgres schema updates to PaaS services

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # di-auth-oidc-provider
 
 A Dropwizard-based OpenID Connect provider
+
+# Database Migrations
+
+- Database schema scripts are stored in `sql/` using Flyway naming conventions (e.g. `V*_<description>.sql` or `R_<description>.sql`)
+- Scripts are automatically applied when started locally in Docker Compose.
+- To apply to a PaaS environment execute `cf conduit <service-name> -- ./db-migrate.sh`

--- a/db-migrate.sh
+++ b/db-migrate.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -eu
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+OS=$(uname -s)
+case "${OS}" in
+  Darwin*)
+    PGHOST=host.docker.internal
+    NETWORK=bridge
+    ;;
+  Linux*)
+    NETWORK=host
+    ;;
+esac
+
+docker run -it \
+  -e FLYWAY_URL="jdbc:postgresql://${PGHOST}:${PGPORT}/${PGDATABASE}" \
+  -e FLYWAY_USER="${PGUSER}" \
+  -e FLYWAY_PASSWORD="${PGPASSWORD}" \
+  -v "${SCRIPT_DIR}/sql:/flyway/sql" \
+  --network "${NETWORK}" \
+  flyway/flyway:6.2.1 migrate -locations=filesystem:/flyway/sql

--- a/sql/V1__create_client_configuration_table.sql
+++ b/sql/V1__create_client_configuration_table.sql
@@ -1,4 +1,4 @@
-CREATE TABLE client (
+CREATE TABLE IF NOT EXISTS client (
     client_id VARCHAR(64) NOT NULL,
     client_secret VARCHAR(64) NOT NULL,
     scopes JSONB NOT NULL,

--- a/sql/V3__create_whitelist_table.sql
+++ b/sql/V3__create_whitelist_table.sql
@@ -1,3 +1,3 @@
-CREATE TABLE registration_whitelist (
+CREATE TABLE IF NOT EXISTS registration_whitelist (
     email VARCHAR(256) NOT NULL,
     PRIMARY KEY (email));


### PR DESCRIPTION
## What?

Add script to aid applying Postgres schema updates to PaaS services
Update README.md to explain usage.

## Why?

We currently don't have a pipeline to apply these, so this makes it easier to run from developer workstations.

