### PR TITLE
BAU: Add callback URL for the IPV stub instance

### DIFF
--- a/sql/R__insert_client_configuration.sql
+++ b/sql/R__insert_client_configuration.sql
@@ -1,7 +1,7 @@
 INSERT INTO client (client_name, client_id, client_secret, scopes, allowed_response_types, redirect_urls, contacts )
 VALUES
-    ('Dummy Service', 'some_client_id', 'password', '["openid", "profile", "email"]', '["code"]', '["https://di-auth-stub-relying-party.london.cloudapps.digital/oidc/callback", "http://localhost:8081/oidc/callback", "https://localhost:5001/signin-oidc", "http://localhost:8082/login/oauth2/code/custom", "http://localhost:5000/callback"]', '["test@test.digital.cabinet-office.gov.uk"]'),
-    ('Client Registration Service', 'admin_client_id', 'admin_client_secret', '["openid", "profile", "email"]', '["code"]', '["https://di-auth-oidc-provider.london.cloudapps.digital/client/callback", "http://localhost:8080/client/callback"]', '["test@test.digital.cabinet-office.gov.uk"]')
+    ('Dummy Service', 'some_client_id', 'password', '["openid", "profile", "email"]', '["code"]', '["https://di-auth-stub-relying-party.london.cloudapps.digital/oidc/callback", "https://di-ipv-stub-relying-party.london.cloudapps.digital/oidc/callback", "http://localhost:8081/oidc/callback", "https://localhost:5001/signin-oidc", "http://localhost:8082/login/oauth2/code/custom", "http://localhost:5000/callback"]', '["test@test.digital.cabinet-office.gov.uk"]'),
+    ('Client Registration Service', 'admin_client_id', 'admin_client_secret', '["openid", "profile", "email"]', '["code"]', '["https://di-auth-oidc-provider.london.cloudapps.digital/client/callback", "https://di-ipv-oidc-provider.london.cloudapps.digital/client/callback", "http://localhost:8080/client/callback"]', '["test@test.digital.cabinet-office.gov.uk"]')
 ON CONFLICT (client_id) DO UPDATE SET client_name = EXCLUDED.client_name, client_secret = EXCLUDED.client_secret, scopes = EXCLUDED.scopes, allowed_response_types = EXCLUDED.allowed_response_types, redirect_urls = EXCLUDED.redirect_urls, contacts = EXCLUDED.contacts
 ;
 


### PR DESCRIPTION
## What?

Add the callback URL of the stub RP in the IPV PaaS space.

## Why?

The IPV team are running a copy of this service in our PaaS. We are trying to not have too much special config and where practical to keep it in this repo. This addition seems to fit the criteria.
