### PR TITLE
LTG-109: Use assume role in Terraform

### DIFF
--- a/ci/pipeline.yaml
+++ b/ci/pipeline.yaml
@@ -66,6 +66,7 @@ jobs:
                 cd di-auth-oidc-provider
                 gradle --no-daemon :serverless:lambda:buildZip
                 cp serverless/lambda/build/distributions/lambda.zip ../lambda-zip/
+
       - task: terraform-plan
         config:
           platform: linux
@@ -79,10 +80,6 @@ jobs:
             - name: di-auth-oidc-provider
           outputs:
             - name: terraform-plan
-          params:
-            AWS_ACCESS_KEY_ID: ((aws_access_key_id))
-            AWS_SECRET_ACCESS_KEY: ((aws_secret_access_key))
-            AWS_REGION: eu-west-2
           run:
             path: /bin/sh
             args:
@@ -104,10 +101,6 @@ jobs:
             - name: lambda-zip
             - name: di-auth-oidc-provider
             - name: terraform-plan
-          params:
-            AWS_ACCESS_KEY_ID: ((aws_access_key_id))
-            AWS_SECRET_ACCESS_KEY: ((aws_secret_access_key))
-            AWS_REGION: eu-west-2
           run:
             path: /bin/sh
             args:

--- a/ci/terraform/site.tf
+++ b/ci/terraform/site.tf
@@ -18,4 +18,8 @@ terraform {
 
 provider "aws" {
   region  = "eu-west-2"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${var.aws_account}:role/${var.deployer_role}"
+  }
 }

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -1,5 +1,16 @@
 variable "lambda-zip-file" {
-  default = "../../serverless/lambda/build/distributions/lambda.zip"
+  default     = "../../serverless/lambda/build/distributions/lambda.zip"
   description = "Location of the Lambda ZIP file"
-  type = string
+  type        = string
+}
+
+variable "aws_account" {
+  default = "761723964695"
+  type    = string
+}
+
+variable "deployer_role" {
+  default     = "concourse-deployer"
+  description = "The name of the AWS role to assume, when running locally use developer admin role (i.e. '<firstname>.<surname>-admin'"
+  type        = string
 }


### PR DESCRIPTION
## What?

- We have now created a "concourse-deployer" role for the pipeline that can be assumed by the Concourse workers.
- Use this new role by configuring Terraform to assume it rather than injecting tokens.
- This can be overridden when running locally by using dev role, e.g. `terraform apply -var 'deployer_role=chris.clayson-admin`

## Why?

Injecting long-lived access tokens, is not the best practice, after merging we will destroy those tokens.