### PR TITLE
BAU: Inject assume role ARN into Terraform in pipeline

### DIFF
--- a/ci/pipeline.yaml
+++ b/ci/pipeline.yaml
@@ -41,7 +41,6 @@ jobs:
       - set_pipeline: di-auth-oidc-provider
         file: pipeline-src/ci/pipeline.yaml
 
-
   - name: deploy-lambda
     plan:
       - get: di-auth-oidc-provider
@@ -75,6 +74,8 @@ jobs:
             source:
               repository: hashicorp/terraform
               tag: 0.14.10
+          params:
+            DEPLOYER_ROLE_ARN: ((deployer-role-arn))
           inputs:
             - name: lambda-zip
             - name: di-auth-oidc-provider
@@ -86,8 +87,11 @@ jobs:
               - -euc
               - |
                 cd di-auth-oidc-provider/ci/terraform
-                terraform init
-                terraform plan -var 'lambda-zip-file=../../../lambda-zip/lambda.zip' -out=../../../terraform-plan/terraform.plan
+                terraform init -input=false -backend-config "role_arn=${DEPLOYER_ROLE_ARN}"
+                terraform plan \
+                  -var 'lambda-zip-file=../../../lambda-zip/lambda.zip' \
+                  -var "deployer-role-arn=${DEPLOYER_ROLE_ARN}" \
+                  -out=../../../terraform-plan/terraform.plan
 
       - task: terraform-apply
         config:
@@ -97,6 +101,8 @@ jobs:
             source:
               repository: hashicorp/terraform
               tag: 0.14.10
+          params:
+            DEPLOYER_ROLE_ARN: ((deployer-role-arn))
           inputs:
             - name: lambda-zip
             - name: di-auth-oidc-provider
@@ -107,7 +113,7 @@ jobs:
               - -euc
               - |
                 cd di-auth-oidc-provider/ci/terraform
-                terraform init
+                terraform init -input=false -backend-config "role_arn=${DEPLOYER_ROLE_ARN}"
                 terraform apply -auto-approve ../../../terraform-plan/terraform.plan
 
   - name: deploy-app

--- a/ci/terraform/site.tf
+++ b/ci/terraform/site.tf
@@ -20,6 +20,6 @@ provider "aws" {
   region  = "eu-west-2"
 
   assume_role {
-    role_arn = "arn:aws:iam::${var.aws_account}:role/${var.deployer_role}"
+    role_arn = var.deployer-role-arn
   }
 }

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -4,13 +4,8 @@ variable "lambda-zip-file" {
   type        = string
 }
 
-variable "aws_account" {
-  default = "761723964695"
-  type    = string
-}
-
-variable "deployer_role" {
-  default     = "concourse-deployer"
-  description = "The name of the AWS role to assume, when running locally use developer admin role (i.e. '<firstname>.<surname>-admin'"
+variable "deployer-role-arn" {
+  default     = ""
+  description = "The name of the AWS role to assume, leave blank when running locally"
   type        = string
 }


### PR DESCRIPTION
## What?

We need to inject the role ARN into Terraform in two places, once for the state backend and once for the AWS provider.
The ARN has been configured in parameter store in the key /cd/concourse/pipelines/verify/di-auth-oidc-provider/deployer-role-arn.
Leaving this parameter blank will allow it be run locally having first done a `eval $(gds aws digital-identity-dev -e)`

## Why?

The pipeline is currently failing because it can't read the state bucket.
This change also makes it easier to run locally without additional parameters.

#Related PRs

#87 