### PR TITLE
LTG-21 - Set the charset to utf-8 in the meta tag

### DIFF
--- a/src/main/java/uk/gov/di/resources/LoginResource.java
+++ b/src/main/java/uk/gov/di/resources/LoginResource.java
@@ -60,7 +60,6 @@ public class LoginResource {
             return Response.ok(new PasswordView(authRequest, email)).build();
         } else {
             URI destination = UriBuilder.fromUri(URI.create("/registration")).build();
-
             return Response.status(Response.Status.TEMPORARY_REDIRECT)
                     .location(destination)
                     .build();

--- a/src/main/java/uk/gov/di/services/CognitoService.java
+++ b/src/main/java/uk/gov/di/services/CognitoService.java
@@ -48,10 +48,8 @@ public class CognitoService implements AuthenticationService {
     @Override
     public boolean userExists(String email) {
         try {
-
             cognitoClient.adminGetUser(
                     AdminGetUserRequest.builder().userPoolId(userPoolId).username(email).build());
-
         } catch (CognitoIdentityProviderException e) {
             return false;
         }

--- a/src/main/resources/uk/gov/di/views/layout.mustache
+++ b/src/main/resources/uk/gov/di/views/layout.mustache
@@ -5,6 +5,7 @@
     <title>{{$title}}GOV.UK{{/title}}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#0b0c0c">
+    <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="/assets/images/favicon.ico" type="image/x-icon">
     <link rel="mask-icon" href="/assets/images/govuk-mask-icon.svg" color="#0b0c0c">


### PR DESCRIPTION
## What?

- The copyright symbol was showing a 'Â' special character before it. 
- Access the Stub RP https://di-auth-stub-relying-party.london.cloudapps.digital/ and click `GOV.UK Account`. At the bottom you can then see the Crown copyright symbol with the special char before. 
- Remove some whitespace 

## Why?

- We can mitigate this by explicitly setting the encoding to UTF-8 in the layout.mustache
