### PR TITLE
LTG-101: exclude acceptance-tests:test task when running build

### DIFF
--- a/ci/pipeline.yaml
+++ b/ci/pipeline.yaml
@@ -139,7 +139,7 @@ jobs:
             - -euc
             - |
               cd di-auth-oidc-provider
-              gradle --no-daemon build
+              gradle --no-daemon build -x :acceptance-tests:test
               cp build/distributions/di-auth-oidc-provider.zip ../di-auth-oidc-provider-zip/
     - put: di-auth-oidc-provider-upload
       params:


### PR DESCRIPTION
## What?

Exclude acceptance-tests:test task when running build.

## Why?

Cucumber tests cannot currently be run in the pipeline so the deploy task is failing.
