### PR TITLE
LTF-134 - Validate passwords

### DIFF
--- a/src/main/java/uk/gov/di/OidcProviderApplication.java
+++ b/src/main/java/uk/gov/di/OidcProviderApplication.java
@@ -75,17 +75,17 @@ public class OidcProviderApplication extends Application<OidcProviderConfigurati
                 new ClientService(clientConfigService.getClients(), authorizationCodeService, clientConfigService);
         var authenticationService = getAuthenticationService(configuration);
         var tokenService = new TokenService(configuration);
+        var validationService = new ValidationService();
 
         env.jersey().register(new OidcClientResource(configuration, clientConfigService));
         env.jersey().register(new AuthorisationResource(clientService));
-        env.jersey().register(new LoginResource(authenticationService, clientService, new ValidationService()));
-        env.jersey().register(new RegistrationResource(authenticationService));
+        env.jersey().register(new LoginResource(authenticationService, clientService, validationService));
+        env.jersey().register(new RegistrationResource(authenticationService, validationService));
         env.jersey().register(new UserInfoResource(tokenService, authenticationService));
         env.jersey()
                 .register(new TokenResource(tokenService, clientService, authenticationService, authorizationCodeService));
         env.jersey().register(new LogoutResource());
         env.jersey().register(new WellKnownResource(tokenService, configuration));
-        env.jersey().register(new RegistrationResource(authenticationService));
         env.jersey().register(new ClientRegistrationResource(clientService, configuration));
         env.jersey()
                 .property(ServerProperties.LOCATION_HEADER_RELATIVE_URI_RESOLUTION_DISABLED, true);

--- a/src/main/java/uk/gov/di/services/ValidationService.java
+++ b/src/main/java/uk/gov/di/services/ValidationService.java
@@ -25,19 +25,23 @@ public class ValidationService {
 
     public Set<PasswordValidation> validatePassword(String password, String retypedPassword) {
         Set<PasswordValidation> passwordErrors = EnumSet.noneOf(PasswordValidation.class);
-        if (password.isBlank()) {
+        boolean passwordIsEmpty = false;
+        boolean retypedPasswordIsEmpty = false;
+        if (password == null  || password.isBlank()) {
             passwordErrors.add(PasswordValidation.EMPTY_PASSWORD_FIELD);
+            passwordIsEmpty = true;
         }
-        if (retypedPassword.isBlank()) {
+        if (retypedPassword == null || retypedPassword.isBlank()) {
             passwordErrors.add(PasswordValidation.EMPTY_RETYPE_PASSWORD_FIELD);
+            retypedPasswordIsEmpty = true;
         }
-        if (!password.isBlank() && password.length() < 8) {
+        if (!passwordIsEmpty && password.length() < 8) {
             passwordErrors.add(PasswordValidation.PASSWORD_TOO_SHORT);
         }
-        if (!password.isBlank() && !PASSWORD_REGEX.matcher(password).matches()) {
+        if (!passwordIsEmpty && !PASSWORD_REGEX.matcher(password).matches()) {
             passwordErrors.add(PasswordValidation.NO_NUMBER_INCLUDED);
         }
-        if (!password.isBlank() && !retypedPassword.isBlank() && !password.equals(retypedPassword)) {
+        if (!passwordIsEmpty && !retypedPasswordIsEmpty && !password.equals(retypedPassword)) {
             passwordErrors.add(PasswordValidation.PASSWORDS_DO_NOT_MATCH);
         }
         return passwordErrors;

--- a/src/main/java/uk/gov/di/services/ValidationService.java
+++ b/src/main/java/uk/gov/di/services/ValidationService.java
@@ -1,6 +1,7 @@
 package uk.gov.di.services;
 
 import uk.gov.di.validation.EmailValidation;
+import uk.gov.di.validation.PasswordValidation;
 
 import java.util.EnumSet;
 import java.util.Set;
@@ -9,6 +10,7 @@ import java.util.regex.Pattern;
 public class ValidationService {
 
     private static final Pattern EMAIL_REGEX = Pattern.compile("[^@]+@[^@]+\\.[^@]*");
+    private static final Pattern PASSWORD_REGEX = Pattern.compile(".*\\d.*");
 
     public Set<EmailValidation> validateEmailAddress(String email) {
         Set<EmailValidation> emailErrors = EnumSet.noneOf(EmailValidation.class);
@@ -19,5 +21,25 @@ public class ValidationService {
             emailErrors.add(EmailValidation.INCORRECT_FORMAT);
         }
         return emailErrors;
+    }
+
+    public Set<PasswordValidation> validatePassword(String password, String retypedPassword) {
+        Set<PasswordValidation> passwordErrors = EnumSet.noneOf(PasswordValidation.class);
+        if (password.isBlank()) {
+            passwordErrors.add(PasswordValidation.EMPTY_PASSWORD_FIELD);
+        }
+        if (retypedPassword.isBlank()) {
+            passwordErrors.add(PasswordValidation.EMPTY_RETYPE_PASSWORD_FIELD);
+        }
+        if (!password.isBlank() && password.length() < 8) {
+            passwordErrors.add(PasswordValidation.PASSWORD_TOO_SHORT);
+        }
+        if (!password.isBlank() && !PASSWORD_REGEX.matcher(password).matches()) {
+            passwordErrors.add(PasswordValidation.NO_NUMBER_INCLUDED);
+        }
+        if (!password.isBlank() && !retypedPassword.isBlank() && !password.equals(retypedPassword)) {
+            passwordErrors.add(PasswordValidation.PASSWORDS_DO_NOT_MATCH);
+        }
+        return passwordErrors;
     }
 }

--- a/src/main/java/uk/gov/di/validation/PasswordValidation.java
+++ b/src/main/java/uk/gov/di/validation/PasswordValidation.java
@@ -1,0 +1,10 @@
+package uk.gov.di.validation;
+
+public enum PasswordValidation {
+
+    EMPTY_PASSWORD_FIELD,
+    EMPTY_RETYPE_PASSWORD_FIELD,
+    PASSWORD_TOO_SHORT,
+    NO_NUMBER_INCLUDED,
+    PASSWORDS_DO_NOT_MATCH
+}

--- a/src/main/java/uk/gov/di/views/SetPasswordView.java
+++ b/src/main/java/uk/gov/di/views/SetPasswordView.java
@@ -1,22 +1,29 @@
 package uk.gov.di.views;
 
 import io.dropwizard.views.View;
+import uk.gov.di.validation.PasswordValidation;
+
+import java.util.EnumSet;
+import java.util.Set;
 
 public class SetPasswordView extends View {
 
     private String email;
     private String authRequest;
     private boolean invalidPassword;
+    private Set<PasswordValidation> passwordErrors = EnumSet.noneOf(PasswordValidation.class);
 
     public SetPasswordView(String email, String authRequest) {
-        this(email, authRequest, false);
-    }
-
-    public SetPasswordView(String email, String authRequest, boolean invalidPassword) {
         super("set-password.mustache");
         this.email = email;
         this.authRequest = authRequest;
-        this.invalidPassword = invalidPassword;
+    }
+
+    public SetPasswordView(String email, String authRequest, Set<PasswordValidation> passwordErrors) {
+        super("set-password.mustache");
+        this.email = email;
+        this.authRequest = authRequest;
+        this.passwordErrors = passwordErrors;
     }
 
     public String getEmail() {
@@ -29,5 +36,29 @@ public class SetPasswordView extends View {
 
     public String getAuthRequest() {
         return authRequest;
+    }
+
+    public boolean isPasswordEmpty() {
+        return passwordErrors.contains(PasswordValidation.EMPTY_PASSWORD_FIELD);
+    }
+
+    public boolean isRetypePasswordEmpty() {
+        return passwordErrors.contains(PasswordValidation.EMPTY_RETYPE_PASSWORD_FIELD);
+    }
+
+    public boolean isPasswordTooShort() {
+        return passwordErrors.contains(PasswordValidation.PASSWORD_TOO_SHORT);
+    }
+
+    public boolean isPasswordNotContainingNumber() {
+        return passwordErrors.contains(PasswordValidation.NO_NUMBER_INCLUDED);
+    }
+
+    public boolean isPasswordFieldsNotMatching() {
+        return passwordErrors.contains(PasswordValidation.PASSWORDS_DO_NOT_MATCH);
+    }
+
+    public boolean isPasswordInvalid() {
+        return !passwordErrors.isEmpty();
     }
 }

--- a/src/main/resources/uk/gov/di/views/set-password.mustache
+++ b/src/main/resources/uk/gov/di/views/set-password.mustache
@@ -15,22 +15,22 @@
                             <ul class="govuk-list govuk-error-summary__list">
                                 {{#passwordEmpty}}
                                 <li>
-                                    <a>Enter your password</a>
+                                    <a href="#password-empty-error">Enter your password</a>
                                 </li>
                                 {{/passwordEmpty}}
                                 {{#retypePasswordEmpty}}
                                 <li>
-                                    <a>Retype your password</a>
+                                    <a href="#retype-password-empty-error">Retype your password</a>
                                 </li>
                                 {{/retypePasswordEmpty}}
                                 {{#passwordTooShort}}
                                 <li>
-                                    <a>Your password must be 8 characters or more</a>
+                                    <a href="#password-too-short-error">Your password must be 8 characters or more</a>
                                 </li>
                                 {{/passwordTooShort}}
                                 {{#passwordNotContainingNumber}}
                                 <li>
-                                    <a>Your password must include a number</a>
+                                    <a href="#password-not-containing-number-error">Your password must include a number</a>
                                 </li>
                                 {{/passwordNotContainingNumber}}
                                 {{#passwordFieldsNotMatching}}

--- a/src/main/resources/uk/gov/di/views/set-password.mustache
+++ b/src/main/resources/uk/gov/di/views/set-password.mustache
@@ -6,38 +6,80 @@
                 <h1 class="govuk-heading-l">
                     Create your GOV.UK account password
                 </h1>
-                {{#invalidPassword}}
+                {{#passwordInvalid}}
                     <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
                         <h2 class="govuk-error-summary__title" id="error-summary-title">
                             There is a problem
                         </h2>
                         <div class="govuk-error-summary__body">
                             <ul class="govuk-list govuk-error-summary__list">
+                                {{#passwordEmpty}}
                                 <li>
-                                    <a>Passwords do not match.  Please try again.</a>
+                                    <a>Enter your password</a>
                                 </li>
+                                {{/passwordEmpty}}
+                                {{#retypePasswordEmpty}}
+                                <li>
+                                    <a>Retype your password</a>
+                                </li>
+                                {{/retypePasswordEmpty}}
+                                {{#passwordTooShort}}
+                                <li>
+                                    <a>Your password must be 8 characters or more</a>
+                                </li>
+                                {{/passwordTooShort}}
+                                {{#passwordNotContainingNumber}}
+                                <li>
+                                    <a>Your password must include a number</a>
+                                </li>
+                                {{/passwordNotContainingNumber}}
+                                {{#passwordFieldsNotMatching}}
+                                <li>
+                                    <a>Enter the same password in both fields</a>
+                                </li>
+                                {{/passwordFieldsNotMatching}}
                             </ul>
                         </div>
                     </div>
-                {{/invalidPassword}}
+                {{/passwordInvalid}}
 
-                <form class="form" action="/registration/validate" method="post">
+                <form class="form" action="/registration/validate" method="post" novalidate>
                     <input type="hidden" value="{{authRequest}}" name="authRequest">
                     <input type="hidden" value="{{email}}" name="email">
-                    <div class="govuk-form-group">
-                        <label class="govuk-label" for="email">
+                    <div class="govuk-form-group {{#passwordInvalid}}govuk-form-group--error{{/passwordInvalid}}">
+                        <label class="govuk-label" for="password">
                             <strong>Enter a password</strong>
                         </label>
+                        {{#passwordEmpty}}
+                        <span id="password-empty-error" class="govuk-error-message">
+                            <span class="govuk-visually-hidden">Error:</span> Enter your password
+                        </span>
+                        {{/passwordEmpty}}
+                        {{#passwordTooShort}}
+                        <span id="password-too-short-error" class="govuk-error-message">
+                            <span class="govuk-visually-hidden">Error:</span> Your password must be 8 characters or more
+                        </span>
+                        {{/passwordTooShort}}
+                        {{#passwordNotContainingNumber}}
+                        <span id="password-not-containing-number-error" class="govuk-error-message">
+                            <span class="govuk-visually-hidden">Error:</span> Your password must include a number
+                        </span>
+                        {{/passwordNotContainingNumber}}
                         <div id="password-hint" class="govuk-hint">
                             It needs to be at least 8 characters long and must include at least one number
                         </div>
                         <input class="govuk-input" id="password" name="password" type="password" spellcheck="false" aria-describedby="password-hint">
                     </div>
 
-                    <div class="govuk-form-group">
-                        <label class="govuk-label" for="email">
+                    <div class="govuk-form-group {{#retypePasswordEmpty}}govuk-form-group--error{{/retypePasswordEmpty}}">
+                        <label class="govuk-label" for="password">
                             <strong>Retype password</strong>
                         </label>
+                        {{#retypePasswordEmpty}}
+                        <span id="retype-password-empty-error" class="govuk-error-message">
+                            <span class="govuk-visually-hidden">Error:</span> Retype your password
+                        </span>
+                        {{/retypePasswordEmpty}}
                         <input class="govuk-input" id="password-confirm" name="password-confirm" type="password" spellcheck="false" aria-describedby="password-confirm-hint">
                     </div>
 

--- a/src/test/java/uk/gov/di/resources/LoginResourceTest.java
+++ b/src/test/java/uk/gov/di/resources/LoginResourceTest.java
@@ -31,7 +31,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(DropwizardExtensionsSupport.class)

--- a/src/test/java/uk/gov/di/services/ValidationServiceTest.java
+++ b/src/test/java/uk/gov/di/services/ValidationServiceTest.java
@@ -85,4 +85,12 @@ public class ValidationServiceTest {
         assertEquals(Set.of(PasswordValidation.NO_NUMBER_INCLUDED, PasswordValidation.PASSWORD_TOO_SHORT),
                 validationService.validatePassword(shortPasswordWithNoNumbers, shortPasswordWithNoNumbers));
     }
+
+    @Test
+    public void shouldNotThrowNullPointerIfPasswordInputsAreNull() {
+        assertEquals(Set.of(PasswordValidation.EMPTY_PASSWORD_FIELD, PasswordValidation.EMPTY_RETYPE_PASSWORD_FIELD),
+                validationService.validatePassword(null, null));
+    }
+
+
 }

--- a/src/test/java/uk/gov/di/services/ValidationServiceTest.java
+++ b/src/test/java/uk/gov/di/services/ValidationServiceTest.java
@@ -2,6 +2,7 @@ package uk.gov.di.services;
 
 import org.junit.jupiter.api.Test;
 import uk.gov.di.validation.EmailValidation;
+import uk.gov.di.validation.PasswordValidation;
 
 import java.util.Set;
 
@@ -44,5 +45,44 @@ public class ValidationServiceTest {
         var validEmail = "test@example.gov.uk";
 
         assertTrue(validationService.validateEmailAddress(validEmail).isEmpty());
+    }
+
+    @Test
+    public void shouldRejectPasswordLessThan8Characters() {
+        var shortPassword = "passw0r";
+
+        assertEquals(Set.of(PasswordValidation.PASSWORD_TOO_SHORT),
+                validationService.validatePassword(shortPassword, shortPassword));
+    }
+
+    @Test
+    public void shouldRejectEmptyPasswords() {
+        assertEquals(Set.of(PasswordValidation.EMPTY_PASSWORD_FIELD, PasswordValidation.EMPTY_RETYPE_PASSWORD_FIELD),
+                validationService.validatePassword("", ""));
+    }
+
+    @Test
+    public void shouldRejectPasswordWhichDoesntContainNumber() {
+        var noNumberPassword = "password";
+
+        assertEquals(Set.of(PasswordValidation.NO_NUMBER_INCLUDED),
+                validationService.validatePassword(noNumberPassword, noNumberPassword));
+    }
+
+    @Test
+    public void shouldRejectPasswordWhichDoesntMatchRetypedPasword() {
+        var passwordOne = "password1";
+        var passwordTwo = "password2";
+
+        assertEquals(Set.of(PasswordValidation.PASSWORDS_DO_NOT_MATCH),
+                validationService.validatePassword(passwordOne, passwordTwo));
+    }
+
+    @Test
+    public void shouldGiveMultipleErrorsForShortPasswordWithNoNumbers() {
+        var shortPasswordWithNoNumbers = "pass";
+
+        assertEquals(Set.of(PasswordValidation.NO_NUMBER_INCLUDED, PasswordValidation.PASSWORD_TOO_SHORT),
+                validationService.validatePassword(shortPasswordWithNoNumbers, shortPasswordWithNoNumbers));
     }
 }


### PR DESCRIPTION
## What?

- Validate that the password is not empty.
- Validate that the retyped password is not empty.
- Validate that the password is at least 8 characters long.
- Validate that the password contains a number.
- Validate that the 2 password fields match
- Depending on where the validation fails, add the correct error message in the format outlined in the GOV.UK design system. The error messages have been documented here - https://docs.google.com/document/d/190S1eOHxrDKJdZDpYg2qJx5ObRHycU4oCVECOm5JoTo/edit
- Switch off HTML5 validation on the form as advised in the design system docs https://design-system.service.gov.uk/patterns/validation/

## Why?

- So we can be confident that the user has selected a secure password
