### PR TITLE
LTG-17 - Add error summary to enter email page

### DIFF
--- a/src/main/java/uk/gov/di/views/LoginView.java
+++ b/src/main/java/uk/gov/di/views/LoginView.java
@@ -49,4 +49,7 @@ public class LoginView extends View {
         return !errorSet.isEmpty();
     }
 
+    public boolean isErrorPresent() {
+        return !errorSet.isEmpty() || failedLogin;
+    }
 }

--- a/src/main/resources/uk/gov/di/views/login.mustache
+++ b/src/main/resources/uk/gov/di/views/login.mustache
@@ -6,20 +6,32 @@
                 <h1 class="govuk-heading-l">
                     Sign in to or create your GOV.UK Account
                 </h1>
-                {{#failedLogin}}
+                {{#errorPresent}}
                     <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
                         <h2 class="govuk-error-summary__title" id="error-summary-title">
                             There is a problem
                         </h2>
                         <div class="govuk-error-summary__body">
                             <ul class="govuk-list govuk-error-summary__list">
+                                {{#failedLogin}}
                                 <li>
                                     <a>The user credentials are not valid.  Please try again.</a>
                                 </li>
+                                {{/failedLogin}}
+                                {{#incorrectEmailFormat}}
+                                <li>
+                                    <a href="#email-format-error">Enter an email address in the correct format, like name@example.com</a>
+                                </li>
+                                {{/incorrectEmailFormat}}
+                                {{#emailEmpty}}
+                                <li>
+                                    <a href="#email-empty-error">Enter your email address</a>
+                                </li>
+                                {{/emailEmpty}}
                             </ul>
                         </div>
                     </div>
-                {{/failedLogin}}
+                {{/errorPresent}}
 
                 <div class="govuk-inset-text">
                     A GOV.UK Account is separate from other government accounts (for example a personal tax account or Government Gateway).<br><!-- A GOV.UK Account will become the single sign-on for all of government. -->
@@ -62,12 +74,12 @@
                             Email address
                         </label>
                         {{#emailEmpty}}
-                            <span id="email-error" class="govuk-error-message">
+                            <span id="email-empty-error" class="govuk-error-message">
                             <span class="govuk-visually-hidden">Error:</span> Enter your email address
                         </span>
                         {{/emailEmpty}}
                         {{#incorrectEmailFormat}}
-                        <span id="email-error" class="govuk-error-message">
+                        <span id="email-format-error" class="govuk-error-message">
                             <span class="govuk-visually-hidden">Error:</span> Enter an email address in the correct format, like name@example.com
                         </span>
                         {{/incorrectEmailFormat}}


### PR DESCRIPTION
## What?

- Display any email errors in the error summary at the top of the page as explained in the GOV.UK Design system https://design-system.service.gov.uk/components/error-summary/

## Why?

- Because when a user makes an error, we must show both an error summary and an error message next to each answer that contains an error.