### PR TITLE
LTG-101: Fix cf push issue in pipeline.

### DIFF
--- a/ci/pipeline.yaml
+++ b/ci/pipeline.yaml
@@ -143,7 +143,14 @@ jobs:
     - put: di-auth-oidc-provider-upload
       params:
         command: push
+        app_name: di-auth-oidc-provider
         manifest: di-auth-oidc-provider/manifest.yml
         path: di-auth-oidc-provider-zip/di-auth-oidc-provider.zip
+
+    - put: di-auth-oidc-provider-upload
+      params:
+        command: push
+        app_name: selenium-firefox
+        manifest: di-auth-oidc-provider/manifest.yml
 
 


### PR DESCRIPTION
## What?

The CF resource doesn't allow you to push two apps in the same manifest with additional parameters. Split the into two pushes.

## Why?

The pipeline is failing.

## Related PRs

#93 