### PR TITLE
LTG-101: Run Selenium in Docker Compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
 FROM gradle:jdk16@sha256:d31e12d105e332ec2ef1f31c20eac6d1467295487ac70e534e3c1d0ae4a0506e AS build
 COPY --chown=gradle:gradle . /home/gradle/src
 WORKDIR /home/gradle/src
-RUN gradle build --no-daemon
+RUN gradle build --no-daemon -x :acceptance-tests:test
 
 FROM openjdk:16-slim@sha256:38f6c41a7f4901b734f4a7cfc0daa6a1995b552d7ec9517496788f6cc8090235
 
 ENV PORT 8080
 RUN addgroup --system --gid 1001 appgroup && adduser --system --uid 1001 appuser --gid 1001
 RUN mkdir /app
-
+RUN apt-get update && apt-get install -y curl
 COPY --from=build \
 	/home/gradle/src/build/distributions/src.tar \
 	/home/gradle/src/oidc-provider.yml \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,5 +45,52 @@ services:
     networks:
       - op-net
 
+  selenium:
+    image: selenium/standalone-firefox@sha256:4cee1e9d02dc0ff00683582a678a904991016a4534fa61bda2db11982d5094f4
+    ports:
+      - 4444:4444
+    networks:
+      - op-net
+
+  di-auth-stub-relying-party:
+    image: di-auth-stub-relying-party:local
+    build:
+      context: ../di-auth-stub-relying-party
+    environment:
+      CLIENT_ID: "some_client_id"
+      OP_AUTHORIZE_URL: "http://di-auth-oidc-provider:8080/authorize"
+      OP_TOKEN_URL: "http://di-auth-oidc-provider:8080/token"
+      OP_USERINFO_URL: "http://di-auth-oidc-provider:8080/userinfo"
+      AUTH_CALLBACK_URL: "http://di-auth-stub-relying-party:8081/oidc/callback"
+      LOGOUT_URL: "http://di-auth-oidc-provider:8080/logout?redirectUri=http://di-auth-stub-relying-party:8081"
+      RP_PORT: "8081"
+    healthcheck:
+      test: curl -L http://localhost:8081
+      interval: 5s
+      timeout: 3m
+    ports:
+      - 8081:8081
+    restart: on-failure
+    networks:
+      - op-net
+
+  di-auth-oidc-provider:
+    image: di-auth-oidc-provider:local
+    build:
+      context: .
+    environment:
+      AUTHENTICATION_SERVICE_PROVIDER: user
+      BASE_URL: http://di-auth-oidc-provider:8080/
+      DATABASE_URL: jdbc:postgresql://op-db:5432/store
+    healthcheck:
+      test: curl -L http://localhost:8080/login
+      interval: 5s
+      timeout: 3m
+    ports:
+      - 8080:8080
+    restart: on-failure
+    networks:
+      - op-net
+
 networks:
   op-net:

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -1,13 +1,63 @@
 #!/usr/bin/env bash
+DOCKER_BASE=docker-compose
+function wait_for_docker_services() {
+  RUNNING=0
+  LOOP_COUNT=0
+  echo -n "Waiting for service(s) to become healthy ($*) ."
+  until [[ ${RUNNING} == $# || ${LOOP_COUNT} == 100 ]]; do
+    RUNNING=$(${DOCKER_BASE} ps -q "$@" | xargs docker inspect | jq -rc '[ .[] | select(.State.Health.Status == "healthy")] | length')
+    LOOP_COUNT=$((LOOP_COUNT + 1))
+    echo -n "."
+  done
+  if [[ ${LOOP_COUNT} == 100 ]]; then
+    echo "FAILED"
+    return 1
+  fi
+  echo " done!"
+  return 0
+}
+
+function start_docker_services() {
+  ${DOCKER_BASE} up --build -d --no-deps --quiet-pull "$@"
+}
+
+function stop_docker_services() {
+  ${DOCKER_BASE} down --rmi local --remove-orphans
+}
+
+function build_docker_service() {
+  ${DOCKER_BASE} build --quiet "$@"
+}
 
 printf "\nRunning build and unit tests...\n"
 
-./gradlew clean build
+./gradlew clean build -x :acceptance-tests:test
 
 build_and_test_exit_code=$?
 if [ ${build_and_test_exit_code} -ne 0 ]
 then
     printf "\npre-commit failed.\n"
+    exit 1
+fi
+
+printf "\nRunning build and unit tests...\n"
+build_docker_service op-db flyway
+start_docker_services op-db flyway selenium
+wait_for_docker_services op-db
+
+build_docker_service di-auth-stub-relying-party di-auth-oidc-provider
+start_docker_services di-auth-stub-relying-party di-auth-oidc-provider
+wait_for_docker_services di-auth-stub-relying-party di-auth-oidc-provider
+
+SELENIUM_URL="http://localhost:4444/wd/hub" IDP_URL="http://di-auth-oidc-provider:8080/" RP_URL="http://di-auth-stub-relying-party:8081/" ./gradlew cucumber
+build_and_test_exit_code=$?
+
+stop_docker_services op-db flyway selenium di-auth-stub-relying-party di-auth-oidc-provider
+
+if [ ${build_and_test_exit_code} -ne 0 ]
+then
+    printf "\npre-commit failed.\n"
+
 else
     printf "\npre-commit SUCCEEDED.\n"
 fi

--- a/sql/R__insert_client_configuration.sql
+++ b/sql/R__insert_client_configuration.sql
@@ -1,6 +1,6 @@
 INSERT INTO client (client_name, client_id, client_secret, scopes, allowed_response_types, redirect_urls, contacts )
 VALUES
-    ('Dummy Service', 'some_client_id', 'password', '["openid", "profile", "email"]', '["code"]', '["https://di-auth-stub-relying-party.london.cloudapps.digital/oidc/callback", "http://localhost:8081/oidc/callback", "https://localhost:5001/signin-oidc", "http://localhost:8082/login/oauth2/code/custom", "http://localhost:5000/callback"]', '["test@test.digital.cabinet-office.gov.uk"]'),
+    ('Dummy Service', 'some_client_id', 'password', '["openid", "profile", "email"]', '["code"]', '["https://di-auth-stub-relying-party.london.cloudapps.digital/oidc/callback", "http://localhost:8081/oidc/callback", "http://di-auth-stub-relying-party:8081/oidc/callback","https://localhost:5001/signin-oidc", "http://localhost:8082/login/oauth2/code/custom", "http://localhost:5000/callback"]', '["test@test.digital.cabinet-office.gov.uk"]'),
     ('Client Registration Service', 'admin_client_id', 'admin_client_secret', '["openid", "profile", "email"]', '["code"]', '["https://di-auth-oidc-provider.london.cloudapps.digital/client/callback", "http://localhost:8080/client/callback"]', '["test@test.digital.cabinet-office.gov.uk"]')
 ON CONFLICT (client_id) DO UPDATE SET client_name = EXCLUDED.client_name, client_secret = EXCLUDED.client_secret, scopes = EXCLUDED.scopes, allowed_response_types = EXCLUDED.allowed_response_types, redirect_urls = EXCLUDED.redirect_urls, contacts = EXCLUDED.contacts
 ;


### PR DESCRIPTION
## What?

- Add Selenium service to docker compose
- Add IDP and RP to docker compose with appropirate config
- Add additional callback URL to IDP client table
- Run acceptance tests from pre-commit.sh

Acceptance tests can either be run by manually starting services and then
running `./gradlew cucumber` (which will run everything locally using Firefox web driver),
or by running `./pre-commit.sh`, this will start the services dockerized alongside selenium and
use the RemoteWebDriver to control Selenium.

## Why?

Having the docker-compose option means developers do not need to have Firefox and Gecko web-driver available locally, which has historically caused many problems.
