### PR TITLE
LTG-83 - Add acceptance test for a registration happy path

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/StepDefinitions.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/StepDefinitions.java
@@ -16,6 +16,7 @@ import org.openqa.selenium.remote.RemoteWebDriver;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
+import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -77,6 +78,13 @@ public class StepDefinitions {
     public void theUserHasInvalidPassword() {
         emailAddress = "joe.bloggs+1@digital.cabinet-office.gov.uk";
         password = "password";
+    }
+
+    @And("a new user has valid credentials")
+    public void theNewUserHasValidCredential() {
+        String randomString = UUID.randomUUID().toString();
+        emailAddress = "susan.bloggs+"+randomString+"@digital.cabinet-office.gov.uk";
+        password = "passw0rd1";
     }
 
     @When("the user visit the stub relying party")
@@ -141,6 +149,13 @@ public class StepDefinitions {
     public void theUserIsTakenToTheSuccessPage() {
         assertEquals("/login/validate", URI.create(driver.getCurrentUrl()).getPath());
         assertEquals("Sign-in to GOV.UK - Success", driver.getTitle());
+    }
+
+    @Then("the user is taken to the successfully registered page")
+    public void theUserIsTakenToTheSuccessfullyRegisteredPage() {
+        assertEquals("/registration/validate", URI.create(driver.getCurrentUrl()).getPath());
+        WebElement element = driver.findElement(By.id("successfully-created-account"));
+        assertEquals("You have successfully created your GOV.UK Account", element.getText().trim());
     }
 
     @Then("the user is taken to the Service User Info page")

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/registration_journey.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/registration_journey.feature
@@ -1,6 +1,18 @@
 Feature: Registration Journey
   User walks through a registration journey
 
+  Scenario: User successfully registers
+    Given the services are running
+    And a new user has valid credentials
+    When the user visit the stub relying party
+    And the user clicks "govuk-signin-button"
+    Then the user is taken to the Identity Provider Login Page
+    When the user enters their email address
+    Then the user is asked to create a password
+    When the user registers their password
+    And the user clicks "continue"
+    Then the user is taken to the successfully registered page
+
   Scenario: User registers with an insecure password
     Given the services are running
     And a new user has an insecure password

--- a/src/main/resources/uk/gov/di/views/successful-registration.mustache
+++ b/src/main/resources/uk/gov/di/views/successful-registration.mustache
@@ -5,7 +5,7 @@
             <div class="govuk-grid-column-two-thirds">
 
                 <div class="govuk-panel govuk-panel--confirmation orange-bg">
-                    <h1 class="govuk-panel__title">
+                    <h1 class="govuk-panel__title" id="successfully-created-account">
                         You have successfully created your GOV.UK Account
                     </h1>
 


### PR DESCRIPTION
## What?

- Ensure the new user is unique for each test by generating a UUID. These users will be removed when the server restarts.

## Why?

- So we know that a user can successfully register