### PR TITLE
LTG-101: Secure Access to Selenium from Concourse

### DIFF
--- a/ci/pipeline.yaml
+++ b/ci/pipeline.yaml
@@ -148,6 +148,9 @@ jobs:
           path: di-auth-oidc-provider-zip/di-auth-oidc-provider.zip
 
   - name: acceptance-tests
+    serial: true
+    serial_groups:
+      - selenium-tests
     ensure:
       do:
         - task: tear-down-selenium

--- a/ci/pipeline.yaml
+++ b/ci/pipeline.yaml
@@ -118,53 +118,117 @@ jobs:
 
   - name: deploy-app
     plan:
-    - get: di-auth-oidc-provider
-      trigger: true
-    - task: build
-      config:
-        platform: linux
-        image_resource:
-          type: registry-image
-          source:
-            repository: gradle
-            tag: 7.0.2-jdk16
-        inputs:
-          - name: di-auth-oidc-provider
-        outputs:
-          - name: di-auth-oidc-provider-zip
-        run:
-          path: /bin/bash
-          args:
-            - -euc
-            - |
-              cd di-auth-oidc-provider
-              gradle --no-daemon build -x :acceptance-tests:test
-              cp build/distributions/di-auth-oidc-provider.zip ../di-auth-oidc-provider-zip/
-    - put: di-auth-oidc-provider-upload
-      params:
-        command: push
-        app_name: di-auth-oidc-provider
-        manifest: di-auth-oidc-provider/manifest.yml
-        path: di-auth-oidc-provider-zip/di-auth-oidc-provider.zip
+      - get: di-auth-oidc-provider
+        trigger: true
+      - task: build
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: gradle
+              tag: 7.0.2-jdk16
+          inputs:
+            - name: di-auth-oidc-provider
+          outputs:
+            - name: di-auth-oidc-provider-zip
+          run:
+            path: /bin/bash
+            args:
+              - -euc
+              - |
+                cd di-auth-oidc-provider
+                gradle --no-daemon build -x :acceptance-tests:test
+                cp build/distributions/di-auth-oidc-provider.zip ../di-auth-oidc-provider-zip/
+      - put: di-auth-oidc-provider-upload
+        params:
+          command: push
+          app_name: di-auth-oidc-provider
+          manifest: di-auth-oidc-provider/manifest.yml
+          path: di-auth-oidc-provider-zip/di-auth-oidc-provider.zip
 
   - name: acceptance-tests
     ensure:
       do:
-      - put: di-auth-oidc-provider-upload
-        params:
-          command: delete
-          app_name: selenium-firefox
-          manifest: di-auth-oidc-provider/manifest.yml
+        - task: tear-down-selenium
+          config:
+            platform: linux
+            image_resource:
+              type: registry-image
+              source:
+                repository: governmentpaas/cf-cli
+                tag: "3aa9f06a02907743df5eda0a9ad1b91b2837771b1cd8795e5deb548b9ae425f4"  # pragma: allowlist secret
+            inputs:
+              - name: di-auth-oidc-provider
+            params:
+              CF_USERNAME: ((cf-username))
+              CF_PASSWORD: ((cf-password))
+              CF_API_URL: https://api.london.cloud.service.gov.uk
+              CF_ORG_NAME: gds-digital-identity-authentication
+              CF_SPACE_NAME: sandbox
+            run:
+              path: bash
+              args:
+                - -eu
+                - -c
+                - |
+                  echo "Logging in to CloudFoundry..."
+                  cf login -a "${CF_API_URL}" -u "${CF_USERNAME}" -p "${CF_PASSWORD}" -o "${CF_ORG_NAME}" -s "${CF_SPACE_NAME}"
+
+                  cf unbind-route-service -f london.cloudapps.digital selenium-route-service --hostname selenium
+                  cf delete-service -f selenium-route-service
+                  cf delete -f selenium-route-service-app
+                  cf delete -f selenium
+
     plan:
       - get: di-auth-oidc-provider
         passed:
           - deploy-app
-        trigger: false
-      - put: di-auth-oidc-provider-upload
-        params:
-          command: push
-          app_name: selenium-firefox
-          manifest: di-auth-oidc-provider/manifest.yml
+        trigger: true
+      - task: deploy-selenium
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: governmentpaas/cf-cli
+              tag: "3aa9f06a02907743df5eda0a9ad1b91b2837771b1cd8795e5deb548b9ae425f4"  # pragma: allowlist secret
+          inputs:
+            - name: di-auth-oidc-provider
+          params:
+            CF_USERNAME: ((cf-username))
+            CF_PASSWORD: ((cf-password))
+            CF_API_URL: https://api.london.cloud.service.gov.uk
+            CF_ORG_NAME: gds-digital-identity-authentication
+            CF_SPACE_NAME: sandbox
+            CONCOURSE_EGRESS_IPS: ((readonly_egress_ips))
+          run:
+            path: bash
+            args:
+              - -eu
+              - -c
+              - |
+                echo "Logging in to CloudFoundry..."
+                cf login -a "${CF_API_URL}" -u "${CF_USERNAME}" -p "${CF_PASSWORD}" -o "${CF_ORG_NAME}" -s "${CF_SPACE_NAME}"
+
+                echo "Allowed IPs"
+                echo "${CONCOURSE_EGRESS_IPS}"
+
+                IFS="," read -ra IPS <<< "$CONCOURSE_EGRESS_IPS"
+
+                NGINX_ALLOW_STATEMENTS=""
+                for addr in "${IPS[@]}";
+                  do NGINX_ALLOW_STATEMENTS="$NGINX_ALLOW_STATEMENTS allow $addr/32;";
+                done;
+                echo "${NGINX_ALLOW_STATEMENTS}"
+
+                cd di-auth-oidc-provider/nginx
+
+                cf push --var app-name="selenium-route-service-app" --var allowed-ips="${NGINX_ALLOW_STATEMENTS}"
+
+                cf create-user-provided-service selenium-route-service -r https://selenium-route-service-app.london.cloudapps.digital
+                cf bind-route-service london.cloudapps.digital selenium-route-service --hostname selenium
+
       - task: test
         config:
           platform: linux
@@ -176,7 +240,7 @@ jobs:
           inputs:
             - name: di-auth-oidc-provider
           params:
-            SELENIUM_URL: https://selenium-firefox.london.cloudapps.digital/wd/hub
+            SELENIUM_URL: https://selenium.london.cloudapps.digital/wd/hub
             IDP_URL: https://di-auth-oidc-provider.london.cloudapps.digital
             RP_URL: https://di-auth-stub-relying-party.london.cloudapps.digital
           run:

--- a/manifest.yml
+++ b/manifest.yml
@@ -12,7 +12,3 @@ applications:
       JBP_CONFIG_OPEN_JDK_JRE: '{ jre: { version: 16.+}}'
       AUTHENTICATION_SERVICE_PROVIDER: user
       BASE_URL: https://di-auth-oidc-provider.london.cloudapps.digital/
-
-  - name: selenium-firefox
-    docker:
-      image: selenium/standalone-firefox:latest

--- a/nginx/manifest.yml
+++ b/nginx/manifest.yml
@@ -1,0 +1,18 @@
+---
+
+applications:
+  - name: ((app-name))
+    instances: 2
+    memory: 256M
+
+    buildpacks:
+      - nginx_buildpack
+
+    health-check-type: http
+    health-check-http-endpoint: /_route-service-health
+
+    env:
+      APP_NAME: ((app-name))
+      ALLOWED_IPS: |
+        allow 1.2.3.4/32;
+        allow 2.3.4.5/32;

--- a/nginx/manifest.yml
+++ b/nginx/manifest.yml
@@ -13,6 +13,8 @@ applications:
 
     env:
       APP_NAME: ((app-name))
-      ALLOWED_IPS: |
-        allow 1.2.3.4/32;
-        allow 2.3.4.5/32;
+      ALLOWED_IPS: ((allowed-ips))
+
+  - name: selenium
+    docker:
+      image: selenium/standalone-firefox:latest

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -26,7 +26,11 @@ http {
   default_type application/octet-stream;
   sendfile on;
   tcp_nopush on;
-  keepalive_timeout 30;
+  keepalive_timeout 10;
+  send_timeout 10s;
+  client_header_timeout 10s;
+  client_body_timeout 10s;
+  large_client_header_buffers 2 1k;
   port_in_redirect off;
   server_tokens off;
 
@@ -70,17 +74,7 @@ http {
 
     location = /_route-service-check {
       allow 127.0.0.1/32;
-      allow 213.86.153.212/32;
-      allow 213.86.153.213/32;
-      allow 213.86.153.214/32;
-      allow 213.86.153.235/32;
-      allow 213.86.153.236/32;
-      allow 213.86.153.237/32;
-      allow 35.178.62.180/32;
-      allow 18.130.41.69/32;
-      allow 35.177.73.21/32;
-      allow 35.177.37.128/32;
-      allow 35.176.252.164/32;
+      {{env "ALLOWED_IPS"}}
       deny all;
 
       try_files $uri @check;
@@ -88,17 +82,7 @@ http {
 
     location / {
       allow 127.0.0.1/32;
-      allow 213.86.153.212/32;
-      allow 213.86.153.213/32;
-      allow 213.86.153.214/32;
-      allow 213.86.153.235/32;
-      allow 213.86.153.236/32;
-      allow 213.86.153.237/32;
-      allow 35.178.62.180/32;
-      allow 18.130.41.69/32;
-      allow 35.177.73.21/32;
-      allow 35.177.37.128/32;
-      allow 35.176.252.164/32;
+      {{env "ALLOWED_IPS"}}
       deny all;
 
       resolver 169.254.0.2;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,127 @@
+worker_processes 4;
+daemon off;
+
+error_log /dev/stderr;
+
+events {
+  worker_connections 1024;
+}
+
+http {
+  charset utf-8;
+
+  log_format access_json '{"logType": "nginx-access", '
+                         ' "remoteHost": "$remote_addr", '
+                         ' "user": "$remote_user", '
+                         ' "time": "$time_local", '
+                         ' "request": "$request", '
+                         ' "status": $status, '
+                         ' "size": $body_bytes_sent, '
+                         ' "referer": "$http_referer", '
+                         ' "userAgent": "$http_user_agent", '
+                         ' "requestTime": $request_time, '
+                         ' "httpHost": "$http_host"}';
+
+  access_log /dev/stdout access_json;
+  default_type application/octet-stream;
+  sendfile on;
+  tcp_nopush on;
+  keepalive_timeout 30;
+  port_in_redirect off;
+  server_tokens off;
+
+  expires -1;
+
+  real_ip_header X-Forwarded-For;
+  set_real_ip_from 10.0.0.0/8;
+  set_real_ip_from 127.0.0.1/32;
+  set_real_ip_from 172.16.0.0/12;
+  set_real_ip_from 192.168.0.0/16;
+  real_ip_recursive on;
+
+  server {
+    listen {{ port }};
+    server_name localhost;
+
+    satisfy any;
+
+    error_page 403 = @forbidden;
+
+    location @forbidden {
+      allow all;
+      access_log off;
+
+      default_type text/plain;
+      return 403 'Forbidden by {{ env "APP_NAME" }}';
+    }
+
+    location @check {
+      default_type text/plain;
+      return 200 'OK';
+    }
+
+    location = /_route-service-health {
+      allow all;
+      access_log off;
+
+      stub_status on;
+      access_log off;
+    }
+
+    location = /_route-service-check {
+      allow 127.0.0.1/32;
+      allow 213.86.153.212/32;
+      allow 213.86.153.213/32;
+      allow 213.86.153.214/32;
+      allow 213.86.153.235/32;
+      allow 213.86.153.236/32;
+      allow 213.86.153.237/32;
+      allow 35.178.62.180/32;
+      allow 18.130.41.69/32;
+      allow 35.177.73.21/32;
+      allow 35.177.37.128/32;
+      allow 35.176.252.164/32;
+      deny all;
+
+      try_files $uri @check;
+    }
+
+    location / {
+      allow 127.0.0.1/32;
+      allow 213.86.153.212/32;
+      allow 213.86.153.213/32;
+      allow 213.86.153.214/32;
+      allow 213.86.153.235/32;
+      allow 213.86.153.236/32;
+      allow 213.86.153.237/32;
+      allow 35.178.62.180/32;
+      allow 18.130.41.69/32;
+      allow 35.177.73.21/32;
+      allow 35.177.37.128/32;
+      allow 35.176.252.164/32;
+      deny all;
+
+      resolver 169.254.0.2;
+
+      set $cf_forwarded_host '*';
+      set $cf_forwarded_uri '*';
+
+      if ($http_x_cf_forwarded_url ~* ^(https?\:\/\/)(.*?)\/(.*)$) {
+        set $cf_forwarded_host $2;
+        set $cf_forwarded_uri /$3;
+      }
+
+      proxy_http_version 1.1;
+      proxy_ssl_server_name on;
+      proxy_ssl_protocols TLSv1.2;
+      proxy_set_header Connection "";
+      proxy_set_header Host $cf_forwarded_host;
+      proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+
+      # Use XX-CF-APP-INSTANCE on the original request if you wish to target an instance
+      proxy_set_header X-CF-APP-INSTANCE $http_xx_cf_app_instance;
+
+      proxy_pass $http_x_forwarded_proto://$http_host$cf_forwarded_uri;
+    }
+  }
+}


### PR DESCRIPTION
## What?

- Deploy a route service in front of Selenium to limit access to Concourse workers
- Deploy and teardown Selenium, and its route service, in the Acceptance Test job.

## Why?

To be able to run acceptance in the pipeline but ensure no external actors can send tests to Selenium.
