### PR TITLE
BAU: Make `deploy-app` a serial job co-ordinated with Selenium

### DIFF
--- a/ci/pipeline.yaml
+++ b/ci/pipeline.yaml
@@ -117,6 +117,9 @@ jobs:
                 terraform apply -auto-approve ../../../terraform-plan/terraform.plan
 
   - name: deploy-app
+    serial: true
+    serial_groups:
+      - selenium-tests
     plan:
       - get: di-auth-oidc-provider
         trigger: true


### PR DESCRIPTION
## What?

- Make the `deploy-app` job serial in the same serial group as acceptance tests.

## Why?

- Acceptance tests will fail if another deploy has kicked off and is restarting the app.
